### PR TITLE
Refactor service provider boot and remove duplicate route

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",
@@ -42,7 +42,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider",
             "requires": {
-                "glueful": ">=1.7.1",
+                "glueful": ">=1.7.2",
                 "extensions": []
             }
         }

--- a/src/routes.php
+++ b/src/routes.php
@@ -295,32 +295,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
             return $roleController->getUsers($params, $request);
         });
 
-        /**
-         * @route POST /rbac/roles/bulk
-         * @tag RBAC Roles
-         * @summary Bulk role operations
-         * @description Performs bulk operations on multiple roles
-         * @requiresAuth true
-         * @requestBody action:string="Action to perform (delete, activate, deactivate)"
-         *              role_ids:array=[string="Role UUIDs"]
-         *              force:boolean="Force operation even with dependencies"
-         *              {required=action,role_ids}
-         * @response 200 application/json "Bulk operation completed" {
-         *   success:boolean="true",
-         *   message:string="Success message",
-         *   data:{
-         *     successful:integer="Number of successful operations",
-         *     failed:integer="Number of failed operations",
-         *     errors:array="Error messages for failed operations"
-         *   },
-         * }
-         * @response 400 application/json "Invalid request format"
-         * @response 403 application/json "Permission denied"
-         */
-        $router->post('/bulk', function (Request $request) {
-            $roleController = container()->get(RoleController::class);
-            return $roleController->bulk($request);
-        });
+        // (duplicate definition of POST /rbac/roles/bulk removed)
 
         /**
          * @route POST /rbac/roles/{role_uuid}/assign-users


### PR DESCRIPTION
Improves error handling in AegisServiceProvider by wrapping route and migration registration in try/catch blocks and logging failures. Also removes a duplicate POST /rbac/roles/bulk route definition from routes.php. Updates composer.json to require glueful >=1.7.2 and bumps extension version to 1.1.4.