### PR TITLE
Normalize is_system to boolean and update version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",

--- a/migrations/003_SeedDefaultRoles.php
+++ b/migrations/003_SeedDefaultRoles.php
@@ -51,7 +51,7 @@ class SeedDefaultRoles implements MigrationInterface
                 'slug' => 'superuser',
                 'description' => 'System administrator with full access',
                 'level' => 100,
-                'is_system' => 1,
+                'is_system' => true,
                 'status' => 'active'
             ],
             'administrator' => [
@@ -59,7 +59,7 @@ class SeedDefaultRoles implements MigrationInterface
                 'slug' => 'administrator',
                 'description' => 'Site administrator with management access',
                 'level' => 80,
-                'is_system' => 1,
+                'is_system' => true,
                 'status' => 'active'
             ],
             'manager' => [
@@ -67,7 +67,7 @@ class SeedDefaultRoles implements MigrationInterface
                 'slug' => 'manager',
                 'description' => 'User manager with limited admin access',
                 'level' => 60,
-                'is_system' => 1,
+                'is_system' => true,
                 'status' => 'active'
             ],
             'user' => [
@@ -75,7 +75,7 @@ class SeedDefaultRoles implements MigrationInterface
                 'slug' => 'user',
                 'description' => 'Standard user with basic access',
                 'level' => 10,
-                'is_system' => 1,
+                'is_system' => true,
                 'status' => 'active'
             ]
         ];
@@ -230,7 +230,7 @@ class SeedDefaultRoles implements MigrationInterface
                 $permissionUuids[$key] = $existingPermissionMap[$permission['slug']];
             } else {
                 $permission['uuid'] = Utils::generateNanoID();
-                $permission['is_system'] = 1;
+                $permission['is_system'] = true;
                 $permissionUuids[$key] = $permission['uuid'];
                 $newPermissions[] = $permission;
             }
@@ -318,8 +318,8 @@ class SeedDefaultRoles implements MigrationInterface
         $this->db = new Connection();
 
         // Delete all system roles and permissions (will cascade to role_permissions)
-        $this->db->table('permissions')->where('is_system', 1)->delete();
-        $this->db->table('roles')->where('is_system', 1)->delete();
+        $this->db->table('permissions')->where('is_system', true)->delete();
+        $this->db->table('roles')->where('is_system', true)->delete();
     }
 
     /**
@@ -342,7 +342,7 @@ class SeedDefaultRoles implements MigrationInterface
         $existingCorePermissions = $this->db->table('permissions')
             ->select(['slug'])
             ->whereIn('slug', PermissionStandards::CORE_PERMISSIONS)
-            ->where('is_system', 1)
+            ->where('is_system', true)
             ->get();
 
         $existingSlugs = array_column($existingCorePermissions, 'slug');

--- a/src/Repositories/PermissionRepository.php
+++ b/src/Repositories/PermissionRepository.php
@@ -127,6 +127,11 @@ class PermissionRepository extends BaseRepository
     {
         $query = $this->db->table($this->table)->select($this->defaultFields);
 
+        // Normalize boolean filters
+        if (isset($filters['is_system'])) {
+            $filters['is_system'] = (bool) $filters['is_system'];
+        }
+
         if (isset($filters['category'])) {
             $query->where(['category' => $filters['category']]);
         }
@@ -169,7 +174,7 @@ class PermissionRepository extends BaseRepository
 
     public function findSystemPermissions(): array
     {
-        return $this->findAllPermissions(['is_system' => 1]);
+        return $this->findAllPermissions(['is_system' => true]);
     }
 
     public function getCategories(): array
@@ -239,6 +244,7 @@ class PermissionRepository extends BaseRepository
         }
 
         if (isset($filters['is_system'])) {
+            $filters['is_system'] = (bool) $filters['is_system'];
             $query->where(['is_system' => $filters['is_system']]);
         }
 
@@ -266,6 +272,7 @@ class PermissionRepository extends BaseRepository
         }
 
         if (isset($filters['is_system'])) {
+            $filters['is_system'] = (bool) $filters['is_system'];
             $query->where(['is_system' => $filters['is_system']]);
         }
 
@@ -292,7 +299,7 @@ class PermissionRepository extends BaseRepository
         }
 
         if (isset($filters['is_system'])) {
-            $conditions['is_system'] = $filters['is_system'];
+            $conditions['is_system'] = (bool) $filters['is_system'];
         }
 
         // Handle search separately since it needs LIKE queries

--- a/src/Repositories/RoleRepository.php
+++ b/src/Repositories/RoleRepository.php
@@ -120,6 +120,11 @@ class RoleRepository extends BaseRepository
     {
         $query = $this->db->table($this->table)->select($this->defaultFields);
 
+        // Normalize boolean filters
+        if (isset($filters['is_system'])) {
+            $filters['is_system'] = (bool) $filters['is_system'];
+        }
+
         if (isset($filters['status'])) {
             $query->where(['status' => $filters['status']]);
         }
@@ -195,7 +200,7 @@ class RoleRepository extends BaseRepository
 
     public function findSystemRoles(): array
     {
-        return $this->findAllRoles(['is_system' => 1, 'exclude_deleted' => true]);
+        return $this->findAllRoles(['is_system' => true, 'exclude_deleted' => true]);
     }
 
     public function findActiveRoles(): array
@@ -242,6 +247,7 @@ class RoleRepository extends BaseRepository
         }
 
         if (isset($filters['is_system'])) {
+            $filters['is_system'] = (bool) $filters['is_system'];
             $query->where(['is_system' => $filters['is_system']]);
         }
 
@@ -265,7 +271,7 @@ class RoleRepository extends BaseRepository
         }
 
         if (isset($filters['is_system'])) {
-            $conditions['is_system'] = $filters['is_system'];
+            $conditions['is_system'] = (bool) $filters['is_system'];
         }
 
         if (isset($filters['level'])) {

--- a/src/Services/AegisServiceProvider.php
+++ b/src/Services/AegisServiceProvider.php
@@ -60,7 +60,7 @@ class AegisServiceProvider extends ServiceProvider
             $this->app->get(\Glueful\Extensions\ExtensionManager::class)->registerMeta(self::class, [
                 'slug' => 'aegis',
                 'name' => 'Aegis',
-                'version' => '1.1.4',
+                'version' => '1.1.5',
                 'description' => 'Modern, hierarchical role-based access control system',
             ]);
         } catch (\Throwable $e) {


### PR DESCRIPTION
Updated all references to the 'is_system' field to use boolean true instead of integer 1 for consistency across migrations and repositories. Added normalization of 'is_system' filter to boolean in PermissionRepository and RoleRepository. Bumped version to 1.1.5 in composer.json and AegisServiceProvider.