### PR TITLE
Bump Aegis version to 1.1.6 and update dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",
@@ -42,7 +42,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider",
             "requires": {
-                "glueful": ">=1.7.2",
+                "glueful": ">=1.7.3",
                 "extensions": []
             }
         }

--- a/src/Services/AegisServiceProvider.php
+++ b/src/Services/AegisServiceProvider.php
@@ -60,7 +60,7 @@ class AegisServiceProvider extends ServiceProvider
             $this->app->get(\Glueful\Extensions\ExtensionManager::class)->registerMeta(self::class, [
                 'slug' => 'aegis',
                 'name' => 'Aegis',
-                'version' => '1.1.5',
+                'version' => '1.1.6',
                 'description' => 'Modern, hierarchical role-based access control system',
             ]);
         } catch (\Throwable $e) {


### PR DESCRIPTION
Updated Aegis extension version to 1.1.6 in composer.json and service provider. Increased minimum required glueful version to 1.7.3 for compatibility.