### PR TITLE
Bump PHP and Glueful requirements to 8.3 and 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with external identity providers (LDAP, Active Directory)
 - Real-time permission change notifications
 
+## [1.2.0] - 2026-01-17
+
+### Breaking Changes
+- **PHP 8.3 Required**: Minimum PHP version raised from 8.1 to 8.3.
+- **Glueful 1.9.0 Required**: Minimum framework version raised to 1.9.0.
+
+### Changed
+- Updated `composer.json` PHP requirement to `^8.3`.
+- Updated `extra.glueful.requires.glueful` to `>=1.9.0`.
+
+### Notes
+- Ensure your environment runs PHP 8.3 or higher before upgrading.
+- Run `composer update` after upgrading.
+
 ## [1.1.0] - 2025-09-14
 
 Documentation refresh and migration to Glueful’s modern extension architecture.

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1"
+        "php": "^8.3"
     },
     "require-dev": {
         "glueful/framework": "dev-main",
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.1.6",
+            "version": "1.2.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",
@@ -42,7 +42,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider",
             "requires": {
-                "glueful": ">=1.7.3",
+                "glueful": ">=1.9.0",
                 "extensions": []
             }
         }


### PR DESCRIPTION
Raised minimum PHP version to 8.3 and Glueful framework requirement to 1.9.0 in composer.json. Updated version to 1.2.0 and documented these breaking changes in the changelog.