### PR TITLE
Improve caching and DI, update route parameter typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with external identity providers (LDAP, Active Directory)
 - Real-time permission change notifications
 
+## [1.2.1] - 2026-01-24
+
+### Changed
+- **PermissionRepository**: Improved caching to properly handle null results.
+  - Changed from `isset()` to `array_key_exists()` for cache lookups.
+  - Prevents redundant database queries for non-existent permissions.
+  - Applies to both `findPermissionByUuid()` and `findPermissionBySlug()` methods.
+- **AegisServiceProvider**: Added explicit controller registrations to DI container.
+  - `PermissionController`, `RoleController`, `UserRoleController` now registered with dependencies.
+  - Enables proper dependency injection instead of runtime resolution.
+- **Routes**: Updated route handlers to use typed parameters.
+  - Changed from `array $params` to typed parameters (`string $uuid`, `string $user_uuid`, etc.).
+  - Aligns with framework's modern router parameter resolution system.
+  - Improves type safety and IDE autocompletion.
+
+### Notes
+- No breaking changes. All endpoints maintain the same behavior.
+- Compatible with Glueful Framework 1.19.x.
+
 ## [1.2.0] - 2026-01-17
 
 ### Breaking Changes

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",

--- a/src/AegisPermissionProvider.php
+++ b/src/AegisPermissionProvider.php
@@ -396,7 +396,7 @@ class AegisPermissionProvider implements PermissionProviderInterface
     {
         return [
             'name' => 'RBAC Permission Provider',
-            'version' => '1.0.0',
+            'version' => '1.2.1',
             'description' => 'Hierarchical role-based access control with direct user permissions',
             'capabilities' => [
                 'hierarchical_roles',

--- a/src/Repositories/PermissionRepository.php
+++ b/src/Repositories/PermissionRepository.php
@@ -60,44 +60,50 @@ class PermissionRepository extends BaseRepository
 
     public function findPermissionByUuid(string $uuid): ?Permission
     {
+        $cacheKey = 'uuid_' . $uuid;
+
         // Check static cache first (works across all instances)
-        if (isset(self::$globalPermissionsCache['uuid_' . $uuid])) {
-            return self::$globalPermissionsCache['uuid_' . $uuid];
+        // Use array_key_exists to properly cache null results
+        if (array_key_exists($cacheKey, self::$globalPermissionsCache)) {
+            return self::$globalPermissionsCache[$cacheKey];
         }
 
         // Check instance cache
-        if (isset($this->permissionsCache['uuid_' . $uuid])) {
-            return $this->permissionsCache['uuid_' . $uuid];
+        if (array_key_exists($cacheKey, $this->permissionsCache)) {
+            return $this->permissionsCache[$cacheKey];
         }
 
         $result = $this->findRecordByUuid($uuid, $this->defaultFields);
         $permission = $result ? new Permission($result) : null;
 
         // Cache the result in both caches (including null results)
-        $this->permissionsCache['uuid_' . $uuid] = $permission;
-        self::$globalPermissionsCache['uuid_' . $uuid] = $permission;
+        $this->permissionsCache[$cacheKey] = $permission;
+        self::$globalPermissionsCache[$cacheKey] = $permission;
 
         return $permission;
     }
 
     public function findPermissionBySlug(string $slug): ?Permission
     {
+        $cacheKey = 'slug_' . $slug;
+
         // Check static cache first (works across all instances)
-        if (isset(self::$globalPermissionsCache['slug_' . $slug])) {
-            return self::$globalPermissionsCache['slug_' . $slug];
+        // Use array_key_exists to properly cache null results
+        if (array_key_exists($cacheKey, self::$globalPermissionsCache)) {
+            return self::$globalPermissionsCache[$cacheKey];
         }
 
         // Check instance cache
-        if (isset($this->permissionsCache['slug_' . $slug])) {
-            return $this->permissionsCache['slug_' . $slug];
+        if (array_key_exists($cacheKey, $this->permissionsCache)) {
+            return $this->permissionsCache[$cacheKey];
         }
 
         $result = $this->findBySlug($slug, $this->defaultFields);
         $permission = $result ? new Permission($result) : null;
 
         // Cache the result in both caches (including null results to prevent re-querying non-existent permissions)
-        $this->permissionsCache['slug_' . $slug] = $permission;
-        self::$globalPermissionsCache['slug_' . $slug] = $permission;
+        $this->permissionsCache[$cacheKey] = $permission;
+        self::$globalPermissionsCache[$cacheKey] = $permission;
 
         return $permission;
     }

--- a/src/Services/AegisServiceProvider.php
+++ b/src/Services/AegisServiceProvider.php
@@ -14,6 +14,9 @@ use Glueful\Extensions\Aegis\Repositories\RolePermissionRepository;
 use Glueful\Extensions\Aegis\Services\RoleService;
 use Glueful\Extensions\Aegis\Services\PermissionAssignmentService;
 use Glueful\Extensions\Aegis\Services\AuditService;
+use Glueful\Extensions\Aegis\Controllers\PermissionController;
+use Glueful\Extensions\Aegis\Controllers\RoleController;
+use Glueful\Extensions\Aegis\Controllers\UserRoleController;
 
 class AegisServiceProvider extends ServiceProvider
 {
@@ -45,6 +48,34 @@ class AegisServiceProvider extends ServiceProvider
             AuditService::class => ['class' => AuditService::class, 'shared' => true],
 
             AegisPermissionProvider::class => ['class' => AegisPermissionProvider::class, 'shared' => true],
+
+            // Controllers
+            PermissionController::class => [
+                'class' => PermissionController::class,
+                'shared' => true,
+                'arguments' => [
+                    '@' . PermissionAssignmentService::class,
+                    '@' . PermissionRepository::class,
+                    '@' . UserPermissionRepository::class,
+                ],
+            ],
+            RoleController::class => [
+                'class' => RoleController::class,
+                'shared' => true,
+                'arguments' => [
+                    '@' . RoleService::class,
+                    '@' . RoleRepository::class,
+                ],
+            ],
+            UserRoleController::class => [
+                'class' => UserRoleController::class,
+                'shared' => true,
+                'arguments' => [
+                    '@' . RoleService::class,
+                    '@' . PermissionAssignmentService::class,
+                    '@' . UserRoleRepository::class,
+                ],
+            ],
         ];
     }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -148,9 +148,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Role not found"
          */
-        $router->get('/{uuid}', function (array $params) {
+        $router->get('/{uuid}', function (string $uuid) {
             $roleController = container()->get(RoleController::class);
-            return $roleController->show($params);
+            return $roleController->show(['uuid' => $uuid]);
         });
 
         /**
@@ -197,9 +197,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Role not found"
          */
-        $router->put('/{uuid}', function (array $params, Request $request) {
+        $router->put('/{uuid}', function (string $uuid, Request $request) {
             $roleController = container()->get(RoleController::class);
-            return $roleController->update($params, $request);
+            return $roleController->update(['uuid' => $uuid], $request);
         });
 
         /**
@@ -215,9 +215,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Role not found"
          */
-        $router->delete('/{uuid}', function (array $params, Request $request) {
+        $router->delete('/{uuid}', function (string $uuid, Request $request) {
             $roleController = container()->get(RoleController::class);
-            return $roleController->delete($params, $request);
+            return $roleController->delete(['uuid' => $uuid], $request);
         });
 
         /**
@@ -237,9 +237,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Role or user not found"
          */
-        $router->post('/{uuid}/assign', function (array $params, Request $request) {
+        $router->post('/{uuid}/assign', function (string $uuid, Request $request) {
             $roleController = container()->get(RoleController::class);
-            return $roleController->assignToUser($params, $request);
+            return $roleController->assignToUser(['uuid' => $uuid], $request);
         });
 
         /**
@@ -255,9 +255,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Role or user not found"
          */
-        $router->delete('/{uuid}/revoke', function (array $params, Request $request) {
+        $router->delete('/{uuid}/revoke', function (string $uuid, Request $request) {
             $roleController = container()->get(RoleController::class);
-            return $roleController->revokeFromUser($params, $request);
+            return $roleController->revokeFromUser(['uuid' => $uuid], $request);
         });
 
         /**
@@ -289,10 +289,10 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Role not found"
          */
-        $router->get('/{uuid}/users', function (array $params) {
+        $router->get('/{uuid}/users', function (string $uuid) {
             $roleController = container()->get(RoleController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-            return $roleController->getUsers($params, $request);
+            return $roleController->getUsers(['uuid' => $uuid], $request);
         });
 
         // (duplicate definition of POST /rbac/roles/bulk removed)
@@ -314,9 +314,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Role not found"
          */
-        $router->post('/{role_uuid}/assign-users', function (array $params, Request $request) {
+        $router->post('/{role_uuid}/assign-users', function (string $role_uuid, Request $request) {
             $userRoleController = container()->get(UserRoleController::class);
-            return $userRoleController->bulkAssignRoleToUsers($params, $request);
+            return $userRoleController->bulkAssignRoleToUsers(['role_uuid' => $role_uuid], $request);
         });
 
         /**
@@ -332,9 +332,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Role not found"
          */
-        $router->delete('/{role_uuid}/revoke-users', function (array $params, Request $request) {
+        $router->delete('/{role_uuid}/revoke-users', function (string $role_uuid, Request $request) {
             $userRoleController = container()->get(UserRoleController::class);
-            return $userRoleController->bulkRevokeRoleFromUsers($params, $request);
+            return $userRoleController->bulkRevokeRoleFromUsers(['role_uuid' => $role_uuid], $request);
         });
     });
 
@@ -480,9 +480,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Permission not found"
          */
-        $router->get('/{uuid}', function (array $params) {
+        $router->get('/{uuid}', function (string $uuid) {
             $permissionController = container()->get(PermissionController::class);
-            return $permissionController->show($params);
+            return $permissionController->show(['uuid' => $uuid]);
         });
 
         /**
@@ -524,9 +524,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Permission not found"
          */
-        $router->put('/{uuid}', function (array $params, Request $request) {
+        $router->put('/{uuid}', function (string $uuid, Request $request) {
             $permissionController = container()->get(PermissionController::class);
-            return $permissionController->update($params, $request);
+            return $permissionController->update(['uuid' => $uuid], $request);
         });
 
         /**
@@ -542,9 +542,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Permission not found"
          */
-        $router->delete('/{uuid}', function (array $params, Request $request) {
+        $router->delete('/{uuid}', function (string $uuid, Request $request) {
             $permissionController = container()->get(PermissionController::class);
-            return $permissionController->delete($params, $request);
+            return $permissionController->delete(['uuid' => $uuid], $request);
         });
 
         /**
@@ -565,9 +565,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Permission or user not found"
          */
-        $router->post('/{uuid}/assign', function (array $params, Request $request) {
+        $router->post('/{uuid}/assign', function (string $uuid, Request $request) {
             $permissionController = container()->get(PermissionController::class);
-            return $permissionController->assignToUser($params, $request);
+            return $permissionController->assignToUser(['uuid' => $uuid], $request);
         });
 
         /**
@@ -583,9 +583,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "Permission or user not found"
          */
-        $router->delete('/{uuid}/revoke', function (array $params, Request $request) {
+        $router->delete('/{uuid}/revoke', function (string $uuid, Request $request) {
             $permissionController = container()->get(PermissionController::class);
-            return $permissionController->revokeFromUser($params, $request);
+            return $permissionController->revokeFromUser(['uuid' => $uuid], $request);
         });
 
         /**
@@ -654,10 +654,10 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "User not found"
          */
-        $router->get('/{user_uuid}/roles', function (array $params) {
+        $router->get('/{user_uuid}/roles', function (string $user_uuid) {
             $userRoleController = container()->get(UserRoleController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-            return $userRoleController->getUserRoles($params, $request);
+            return $userRoleController->getUserRoles(['user_uuid' => $user_uuid], $request);
         });
 
         /**
@@ -676,9 +676,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 400 application/json "Invalid request format"
          * @response 403 application/json "Permission denied"
          */
-        $router->post('/{user_uuid}/roles', function (array $params, Request $request) {
+        $router->post('/{user_uuid}/roles', function (string $user_uuid, Request $request) {
             $userRoleController = container()->get(UserRoleController::class);
-            return $userRoleController->assignRoles($params, $request);
+            return $userRoleController->assignRoles(['user_uuid' => $user_uuid], $request);
         });
 
         /**
@@ -697,9 +697,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 400 application/json "Invalid request format"
          * @response 403 application/json "Permission denied"
          */
-        $router->put('/{user_uuid}/roles', function (array $params, Request $request) {
+        $router->put('/{user_uuid}/roles', function (string $user_uuid, Request $request) {
             $userRoleController = container()->get(UserRoleController::class);
-            return $userRoleController->replaceUserRoles($params, $request);
+            return $userRoleController->replaceUserRoles(['user_uuid' => $user_uuid], $request);
         });
 
         /**
@@ -714,9 +714,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          * @response 404 application/json "User or role not found"
          */
-        $router->delete('/{user_uuid}/roles/{role_uuid}', function (array $params) {
+        $router->delete('/{user_uuid}/roles/{role_uuid}', function (string $user_uuid, string $role_uuid) {
             $userRoleController = container()->get(UserRoleController::class);
-            return $userRoleController->revokeRole($params);
+            return $userRoleController->revokeRole(['user_uuid' => $user_uuid, 'role_uuid' => $role_uuid]);
         });
 
         /**
@@ -746,10 +746,10 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * }
          * @response 403 application/json "Permission denied"
          */
-        $router->get('/{user_uuid}/permissions', function (array $params) {
+        $router->get('/{user_uuid}/permissions', function (string $user_uuid) {
             $permissionController = container()->get(PermissionController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-            return $permissionController->getUserDirectPermissions($params, $request);
+            return $permissionController->getUserDirectPermissions(['user_uuid' => $user_uuid], $request);
         });
 
         /**
@@ -779,10 +779,10 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * }
          * @response 403 application/json "Permission denied"
          */
-        $router->get('/{user_uuid}/effective-permissions', function (array $params) {
+        $router->get('/{user_uuid}/effective-permissions', function (string $user_uuid) {
             $permissionController = container()->get(PermissionController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-            return $permissionController->getUserEffectivePermissions($params, $request);
+            return $permissionController->getUserEffectivePermissions(['user_uuid' => $user_uuid], $request);
         });
 
         /**
@@ -822,10 +822,10 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * }
          * @response 403 application/json "Permission denied"
          */
-        $router->get('/{user_uuid}/access-overview', function (array $params) {
+        $router->get('/{user_uuid}/access-overview', function (string $user_uuid) {
             $userRoleController = container()->get(UserRoleController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-            return $userRoleController->getUserAccessOverview($params, $request);
+            return $userRoleController->getUserAccessOverview(['user_uuid' => $user_uuid], $request);
         });
 
         /**
@@ -862,10 +862,10 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * }
          * @response 403 application/json "Permission denied"
          */
-        $router->get('/{user_uuid}/role-history', function (array $params) {
+        $router->get('/{user_uuid}/role-history', function (string $user_uuid) {
             $userRoleController = container()->get(UserRoleController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
-            return $userRoleController->getUserRoleHistory($params, $request);
+            return $userRoleController->getUserRoleHistory(['user_uuid' => $user_uuid], $request);
         });
 
         /**
@@ -890,9 +890,9 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 400 application/json "Invalid request format"
          * @response 403 application/json "Permission denied"
          */
-        $router->post('/{user_uuid}/check-role', function (array $params, Request $request) {
+        $router->post('/{user_uuid}/check-role', function (string $user_uuid, Request $request) {
             $userRoleController = container()->get(UserRoleController::class);
-            return $userRoleController->checkUserRole($params, $request);
+            return $userRoleController->checkUserRole(['user_uuid' => $user_uuid], $request);
         });
     });
 


### PR DESCRIPTION
Enhanced PermissionRepository caching to handle null results using array_key_exists, preventing redundant DB queries. Registered controllers with explicit dependencies in AegisServiceProvider for better DI. Updated route handlers to use typed parameters instead of array $params, improving type safety and IDE support. Bumped version to 1.2.1.