### PR TITLE
Update for Glueful 1.22.0 context DI compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with external identity providers (LDAP, Active Directory)
 - Real-time permission change notifications
 
+## [1.3.0] - 2026-01-31
+
+### Changed
+- **Framework Compatibility**: Updated minimum framework requirement to Glueful 1.22.0
+  - Compatible with the new `ApplicationContext` dependency injection pattern
+  - No code changes required in extension - framework handles context propagation
+- **composer.json**: Updated `extra.glueful.requires.glueful` to `>=1.22.0`
+
+### Notes
+- This release ensures compatibility with Glueful Framework 1.22.0's context-based dependency injection
+- All existing functionality remains unchanged
+- Run `composer update` after upgrading
+
 ## [1.2.1] - 2026-01-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -486,8 +486,8 @@ Adjust `Aegis/config/rbac.php` to disable caches or enable check logging as need
 
 ## Requirements
 
-- PHP 8.1 or higher
-- Glueful 1.0.0 or higher
+- PHP 8.3 or higher
+- Glueful 1.22.0 or higher
 - MySQL, PostgreSQL, or SQLite database
 - Redis or Memcached (optional, for distributed caching)
 

--- a/composer.json
+++ b/composer.json
@@ -32,17 +32,21 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",
                 "theme": "dark"
             },
-            "categories": ["authentication", "authorization", "security"],
+            "categories": [
+                "authentication",
+                "authorization",
+                "security"
+            ],
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider",
             "requires": {
-                "glueful": ">=1.9.0",
+                "glueful": ">=1.22.0",
                 "extensions": []
             }
         }
@@ -53,5 +57,14 @@
         "analyse": "phpstan analyse src tests --level=8"
     },
     "minimum-stability": "stable",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../framework",
+            "options": {
+                "symlink": true
+            }
+        }
+    ]
 }

--- a/src/AegisPermissionProvider.php
+++ b/src/AegisPermissionProvider.php
@@ -2,6 +2,7 @@
 
 namespace Glueful\Extensions\Aegis;
 
+use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Interfaces\Permission\PermissionProviderInterface;
 use Glueful\Extensions\Aegis\Repositories\RoleRepository;
 use Glueful\Extensions\Aegis\Repositories\PermissionRepository;
@@ -27,6 +28,7 @@ use Glueful\Cache\CacheStore;
  */
 class AegisPermissionProvider implements PermissionProviderInterface
 {
+    private ApplicationContext $context;
     private ?CacheStore $cache = null;
     private ?RoleRepository $roleRepository = null;
     private ?PermissionRepository $permissionRepository = null;
@@ -46,7 +48,13 @@ class AegisPermissionProvider implements PermissionProviderInterface
     private string $cachePrefix = 'rbac:';
     private bool $cacheEnabled = true;
 
-    public function initialize(array $config = []): void
+    
+    public function __construct(ApplicationContext $context)
+    {
+        $this->context = $context;
+    }
+
+public function initialize(array $config = []): void
     {
         $this->config = array_merge([
             'cache_ttl' => 3600,
@@ -63,7 +71,7 @@ class AegisPermissionProvider implements PermissionProviderInterface
         // Initialize cache store if enabled
         if ($this->cacheEnabled) {
             try {
-                $this->cache = container()->get(CacheStore::class);
+                $this->cache = container($this->context)->get(CacheStore::class);
             } catch (\Exception $e) {
                 // Graceful degradation - disable cache if initialization fails
                 $this->cacheEnabled = false;
@@ -396,7 +404,7 @@ class AegisPermissionProvider implements PermissionProviderInterface
     {
         return [
             'name' => 'RBAC Permission Provider',
-            'version' => '1.2.1',
+            'version' => '1.3.0',
             'description' => 'Hierarchical role-based access control with direct user permissions',
             'capabilities' => [
                 'hierarchical_roles',

--- a/src/Services/AegisServiceProvider.php
+++ b/src/Services/AegisServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Glueful\Extensions\Aegis\Services;
 
+use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Extensions\ServiceProvider;
 use Glueful\Extensions\Aegis\AegisPermissionProvider;
 use Glueful\Extensions\Aegis\Repositories\RoleRepository;
@@ -45,9 +46,9 @@ class AegisServiceProvider extends ServiceProvider
                     '@' . RolePermissionRepository::class,
                 ],
             ],
-            AuditService::class => ['class' => AuditService::class, 'shared' => true],
+            AuditService::class => ['class' => AuditService::class, 'shared' => true, 'autowire' => true],
 
-            AegisPermissionProvider::class => ['class' => AegisPermissionProvider::class, 'shared' => true],
+            AegisPermissionProvider::class => ['class' => AegisPermissionProvider::class, 'shared' => true, 'autowire' => true],
 
             // Controllers
             PermissionController::class => [
@@ -79,19 +80,19 @@ class AegisServiceProvider extends ServiceProvider
         ];
     }
 
-    public function register(): void
+    public function register(ApplicationContext $context): void
     {
         $this->mergeConfig('rbac', require __DIR__ . '/../../config/rbac.php');
     }
 
-    public function boot(): void
+    public function boot(ApplicationContext $context): void
     {
         // 1) Register metadata first so CLI diagnostics always work
         try {
             $this->app->get(\Glueful\Extensions\ExtensionManager::class)->registerMeta(self::class, [
                 'slug' => 'aegis',
                 'name' => 'Aegis',
-                'version' => '1.1.6',
+                'version' => '1.3.0',
                 'description' => 'Modern, hierarchical role-based access control system',
             ]);
         } catch (\Throwable $e) {
@@ -123,7 +124,7 @@ class AegisServiceProvider extends ServiceProvider
             }
 
             $provider = $this->app->get(AegisPermissionProvider::class);
-            $config = config('rbac', []);
+            $config = config($context, 'rbac', []);
             $providerConfig = [
                 'cache_enabled' => $config['permissions']['cache_enabled'] ?? true,
                 'cache_ttl' => $config['permissions']['cache_ttl'] ?? 3600,

--- a/src/Services/AuditService.php
+++ b/src/Services/AuditService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Glueful\Extensions\Aegis\Services;
 
+use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Logging\LogManager;
 use Psr\Log\LoggerInterface;
 
@@ -22,9 +23,11 @@ use Psr\Log\LoggerInterface;
 class AuditService
 {
     private LoggerInterface $logger;
+    private ApplicationContext $context;
 
-    public function __construct(?LoggerInterface $logger = null)
+    public function __construct(ApplicationContext $context, ?LoggerInterface $logger = null)
     {
+        $this->context = $context;
         $this->logger = $logger ?? LogManager::getInstance()->channel('rbac_audit');
     }
     /**
@@ -327,7 +330,7 @@ class AuditService
     ): void {
         // Only log permission checks if explicitly enabled in config
         // This can be very verbose, so it's typically disabled in production
-        $config = config('rbac.logging.log_check_operations', false);
+        $config = config($this->context, 'rbac.logging.log_check_operations', false);
         if (!$config) {
             return;
         }

--- a/src/routes.php
+++ b/src/routes.php
@@ -65,7 +65,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/', function (Request $request) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             return $roleController->index($request);
         });
 
@@ -88,7 +88,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/stats', function (Request $request) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             return $roleController->stats($request);
         });
 
@@ -115,7 +115,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->post('/bulk', function (Request $request) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             return $roleController->bulk($request);
         });
 
@@ -149,7 +149,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Role not found"
          */
         $router->get('/{uuid}', function (string $uuid) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             return $roleController->show(['uuid' => $uuid]);
         });
 
@@ -176,7 +176,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 409 application/json "Role name or slug already exists"
          */
         $router->post('/', function (Request $request) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             return $roleController->create($request);
         });
 
@@ -198,7 +198,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Role not found"
          */
         $router->put('/{uuid}', function (string $uuid, Request $request) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             return $roleController->update(['uuid' => $uuid], $request);
         });
 
@@ -216,7 +216,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Role not found"
          */
         $router->delete('/{uuid}', function (string $uuid, Request $request) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             return $roleController->delete(['uuid' => $uuid], $request);
         });
 
@@ -238,7 +238,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Role or user not found"
          */
         $router->post('/{uuid}/assign', function (string $uuid, Request $request) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             return $roleController->assignToUser(['uuid' => $uuid], $request);
         });
 
@@ -256,7 +256,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Role or user not found"
          */
         $router->delete('/{uuid}/revoke', function (string $uuid, Request $request) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             return $roleController->revokeFromUser(['uuid' => $uuid], $request);
         });
 
@@ -290,7 +290,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Role not found"
          */
         $router->get('/{uuid}/users', function (string $uuid) {
-            $roleController = container()->get(RoleController::class);
+            $roleController = container($router->getContext())->get(RoleController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
             return $roleController->getUsers(['uuid' => $uuid], $request);
         });
@@ -315,7 +315,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Role not found"
          */
         $router->post('/{role_uuid}/assign-users', function (string $role_uuid, Request $request) {
-            $userRoleController = container()->get(UserRoleController::class);
+            $userRoleController = container($router->getContext())->get(UserRoleController::class);
             return $userRoleController->bulkAssignRoleToUsers(['role_uuid' => $role_uuid], $request);
         });
 
@@ -333,7 +333,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Role not found"
          */
         $router->delete('/{role_uuid}/revoke-users', function (string $role_uuid, Request $request) {
-            $userRoleController = container()->get(UserRoleController::class);
+            $userRoleController = container($router->getContext())->get(UserRoleController::class);
             return $userRoleController->bulkRevokeRoleFromUsers(['role_uuid' => $role_uuid], $request);
         });
     });
@@ -376,7 +376,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/', function (Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->index($request);
         });
 
@@ -400,7 +400,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/stats', function (Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->stats($request);
         });
 
@@ -414,7 +414,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->post('/cleanup-expired', function (Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->cleanupExpired($request);
         });
 
@@ -432,7 +432,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/categories', function (Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->getCategories($request);
         });
 
@@ -450,7 +450,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/resource-types', function (Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->getResourceTypes($request);
         });
 
@@ -481,7 +481,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Permission not found"
          */
         $router->get('/{uuid}', function (string $uuid) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->show(['uuid' => $uuid]);
         });
 
@@ -504,7 +504,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 409 application/json "Permission name or slug already exists"
          */
         $router->post('/', function (Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->create($request);
         });
 
@@ -525,7 +525,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Permission not found"
          */
         $router->put('/{uuid}', function (string $uuid, Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->update(['uuid' => $uuid], $request);
         });
 
@@ -543,7 +543,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Permission not found"
          */
         $router->delete('/{uuid}', function (string $uuid, Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->delete(['uuid' => $uuid], $request);
         });
 
@@ -566,7 +566,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Permission or user not found"
          */
         $router->post('/{uuid}/assign', function (string $uuid, Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->assignToUser(['uuid' => $uuid], $request);
         });
 
@@ -584,7 +584,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "Permission or user not found"
          */
         $router->delete('/{uuid}/revoke', function (string $uuid, Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->revokeFromUser(['uuid' => $uuid], $request);
         });
 
@@ -603,7 +603,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->post('/batch-assign', function (Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->batchAssign($request);
         });
 
@@ -621,7 +621,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->post('/batch-revoke', function (Request $request) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             return $permissionController->batchRevoke($request);
         });
     });
@@ -655,7 +655,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "User not found"
          */
         $router->get('/{user_uuid}/roles', function (string $user_uuid) {
-            $userRoleController = container()->get(UserRoleController::class);
+            $userRoleController = container($router->getContext())->get(UserRoleController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
             return $userRoleController->getUserRoles(['user_uuid' => $user_uuid], $request);
         });
@@ -677,7 +677,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->post('/{user_uuid}/roles', function (string $user_uuid, Request $request) {
-            $userRoleController = container()->get(UserRoleController::class);
+            $userRoleController = container($router->getContext())->get(UserRoleController::class);
             return $userRoleController->assignRoles(['user_uuid' => $user_uuid], $request);
         });
 
@@ -698,7 +698,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->put('/{user_uuid}/roles', function (string $user_uuid, Request $request) {
-            $userRoleController = container()->get(UserRoleController::class);
+            $userRoleController = container($router->getContext())->get(UserRoleController::class);
             return $userRoleController->replaceUserRoles(['user_uuid' => $user_uuid], $request);
         });
 
@@ -715,7 +715,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 404 application/json "User or role not found"
          */
         $router->delete('/{user_uuid}/roles/{role_uuid}', function (string $user_uuid, string $role_uuid) {
-            $userRoleController = container()->get(UserRoleController::class);
+            $userRoleController = container($router->getContext())->get(UserRoleController::class);
             return $userRoleController->revokeRole(['user_uuid' => $user_uuid, 'role_uuid' => $role_uuid]);
         });
 
@@ -747,7 +747,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/{user_uuid}/permissions', function (string $user_uuid) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
             return $permissionController->getUserDirectPermissions(['user_uuid' => $user_uuid], $request);
         });
@@ -780,7 +780,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/{user_uuid}/effective-permissions', function (string $user_uuid) {
-            $permissionController = container()->get(PermissionController::class);
+            $permissionController = container($router->getContext())->get(PermissionController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
             return $permissionController->getUserEffectivePermissions(['user_uuid' => $user_uuid], $request);
         });
@@ -823,7 +823,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/{user_uuid}/access-overview', function (string $user_uuid) {
-            $userRoleController = container()->get(UserRoleController::class);
+            $userRoleController = container($router->getContext())->get(UserRoleController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
             return $userRoleController->getUserAccessOverview(['user_uuid' => $user_uuid], $request);
         });
@@ -863,7 +863,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->get('/{user_uuid}/role-history', function (string $user_uuid) {
-            $userRoleController = container()->get(UserRoleController::class);
+            $userRoleController = container($router->getContext())->get(UserRoleController::class);
             $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
             return $userRoleController->getUserRoleHistory(['user_uuid' => $user_uuid], $request);
         });
@@ -891,7 +891,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
          * @response 403 application/json "Permission denied"
          */
         $router->post('/{user_uuid}/check-role', function (string $user_uuid, Request $request) {
-            $userRoleController = container()->get(UserRoleController::class);
+            $userRoleController = container($router->getContext())->get(UserRoleController::class);
             return $userRoleController->checkUserRole(['user_uuid' => $user_uuid], $request);
         });
     });
@@ -921,7 +921,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
      * @response 403 application/json "Permission denied"
      */
     $router->post('/check-permission', function (Request $request) {
-        $permissionController = container()->get(PermissionController::class);
+        $permissionController = container($router->getContext())->get(PermissionController::class);
         return $permissionController->checkPermission($request);
     });
 
@@ -945,7 +945,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
      * @response 403 application/json "Permission denied"
      */
     $router->get('/user-roles/stats', function (Request $request) {
-        $userRoleController = container()->get(UserRoleController::class);
+        $userRoleController = container($router->getContext())->get(UserRoleController::class);
         return $userRoleController->stats($request);
     });
 
@@ -959,7 +959,7 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
      * @response 403 application/json "Permission denied"
      */
     $router->post('/user-roles/cleanup-expired', function (Request $request) {
-        $userRoleController = container()->get(UserRoleController::class);
+        $userRoleController = container($router->getContext())->get(UserRoleController::class);
         return $userRoleController->cleanupExpiredRoles($request);
     });
 });


### PR DESCRIPTION
Refactored service and provider constructors to accept ApplicationContext for context-based dependency injection, updated all usages of container() and config() to pass context, and set minimum Glueful version to 1.22.0 in composer.json and documentation. This ensures full compatibility with Glueful Framework 1.22.0 and its new dependency injection pattern.