### PR TITLE
Read extension version from composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with external identity providers (LDAP, Active Directory)
 - Real-time permission change notifications
 
+## [1.4.1] - 2026-02-06
+
+### Changed
+- **Version Management**: Version is now read from `composer.json` at runtime via `AegisServiceProvider::composerVersion()`.
+  - `registerMeta()` in `boot()` now uses `self::composerVersion()` instead of a hardcoded string.
+  - `AegisPermissionProvider::getProviderInfo()` now references `AegisServiceProvider::composerVersion()`.
+  - Future releases only require updating `composer.json` and `CHANGELOG.md`.
+
+### Notes
+- No breaking changes. Internal refactor only.
+
 ## [1.4.0] - 2026-02-05
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",

--- a/src/AegisPermissionProvider.php
+++ b/src/AegisPermissionProvider.php
@@ -404,7 +404,7 @@ public function initialize(array $config = []): void
     {
         return [
             'name' => 'RBAC Permission Provider',
-            'version' => '1.4.0',
+            'version' => \Glueful\Extensions\Aegis\Services\AegisServiceProvider::composerVersion(),
             'description' => 'Hierarchical role-based access control with direct user permissions',
             'capabilities' => [
                 'hierarchical_roles',

--- a/src/Services/AegisServiceProvider.php
+++ b/src/Services/AegisServiceProvider.php
@@ -21,6 +21,22 @@ use Glueful\Extensions\Aegis\Controllers\UserRoleController;
 
 class AegisServiceProvider extends ServiceProvider
 {
+    private static ?string $cachedVersion = null;
+
+    /**
+     * Read the extension version from composer.json (cached)
+     */
+    public static function composerVersion(): string
+    {
+        if (self::$cachedVersion === null) {
+            $path = __DIR__ . '/../../composer.json';
+            $composer = json_decode(file_get_contents($path), true);
+            self::$cachedVersion = $composer['version'] ?? '0.0.0';
+        }
+
+        return self::$cachedVersion;
+    }
+
     public static function services(): array
     {
         return [
@@ -92,7 +108,7 @@ class AegisServiceProvider extends ServiceProvider
             $this->app->get(\Glueful\Extensions\ExtensionManager::class)->registerMeta(self::class, [
                 'slug' => 'aegis',
                 'name' => 'Aegis',
-                'version' => '1.4.0',
+                'version' => self::composerVersion(),
                 'description' => 'Modern, hierarchical role-based access control system',
             ]);
         } catch (\Throwable $e) {


### PR DESCRIPTION
Add runtime reading of the extension version from composer.json to avoid hardcoded values. Implements AegisServiceProvider::composerVersion() (with caching) and replaces hardcoded '1.4.0' usages in registerMeta() and AegisPermissionProvider::getProviderInfo(). Bumps composer.json to 1.4.1 and updates CHANGELOG.md to document the change. Internal refactor only — no breaking changes.