### PR TITLE
Bump Glueful requirement & update exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with external identity providers (LDAP, Active Directory)
 - Real-time permission change notifications
 
+## [1.5.0] - 2026-02-09
+
+### Changed
+- **Framework Compatibility**: Updated minimum framework requirement to Glueful 1.30.0 (Diphda release)
+- **Exception Imports**: Migrated from deleted legacy bridge classes to modern exception namespaces
+  - `Glueful\Exceptions\NotFoundException` → `Glueful\Http\Exceptions\Client\NotFoundException` in `RoleController` and `PermissionController`
+- **composer.json**: Updated `extra.glueful.requires.glueful` to `>=1.30.0`, version bumped to `1.5.0`
+
+### Notes
+- No breaking changes to extension API. Import path change is internal.
+- Requires Glueful Framework 1.30.0+ due to removal of legacy exception bridge classes.
+
 ## [1.4.1] - 2026-02-06
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",
@@ -46,7 +46,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider",
             "requires": {
-                "glueful": ">=1.28.0",
+                "glueful": ">=1.30.0",
                 "extensions": []
             }
         }

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -8,7 +8,7 @@ use Glueful\Http\Response;
 use Glueful\Extensions\Aegis\Services\PermissionAssignmentService;
 use Glueful\Extensions\Aegis\Repositories\PermissionRepository;
 use Glueful\Extensions\Aegis\Repositories\UserPermissionRepository;
-use Glueful\Exceptions\NotFoundException;
+use Glueful\Http\Exceptions\Client\NotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/src/Controllers/RoleController.php
+++ b/src/Controllers/RoleController.php
@@ -7,7 +7,7 @@ namespace Glueful\Extensions\Aegis\Controllers;
 use Glueful\Http\Response;
 use Glueful\Extensions\Aegis\Services\RoleService;
 use Glueful\Extensions\Aegis\Repositories\RoleRepository;
-use Glueful\Exceptions\NotFoundException;
+use Glueful\Http\Exceptions\Client\NotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 
 /**


### PR DESCRIPTION
Bump extension version to 1.5.0 and require Glueful >=1.30.0; update controllers to use new exception namespace. Changed composer.json to version 1.5.0 and updated extra.glueful.requires to >=1.30.0, updated RoleController and PermissionController to import Glueful\Http\Exceptions\Client\NotFoundException, and added a 1.5.0 entry to CHANGELOG.md. This adapts the extension for Glueful 1.30.0 which removed the legacy exception bridge classes; no extension API breaking changes.