### PR TITLE
Release v1.8.1; bump framework to v1.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-06-20
+
+### Changed
+- Rerelease OpenAPI documentation with framework v1.60.0
+
 ## [1.8.0] - 2026-06-14
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3"
     },
     "require-dev": {
-        "glueful/framework": "^1.57.0",
+        "glueful/framework": "^1.60.0",
         "phpunit/phpunit": "^10.0",
         "phpstan/phpstan": "^1.10"
     },
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",
@@ -46,7 +46,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider",
             "requires": {
-                "glueful": ">=1.57.0",
+                "glueful": ">=1.60.0",
                 "extensions": []
             }
         }


### PR DESCRIPTION
Update composer and metadata for a 1.8.1 release: bump dev dependency glueful/framework to ^1.60.0, update package version to 1.8.1, and raise required glueful core to >=1.60.0. Add CHANGELOG entry for 1.8.1 (2026-06-20) noting a rerelease of OpenAPI documentation with framework v1.60.0.