### PR TITLE
Add role-permission endpoints and implement typed request DTOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-06-23
+
+### Added
+- **Role ↔ permission HTTP endpoints.** The `RolePermissionRepository` was already capable of
+  granting/revoking a role's permissions, but it wasn't exposed over the API. Four new routes on
+  `RoleController` close the gap:
+  - `GET /rbac/roles/{uuid}/permissions` — list a role's permission grants (`roles.view`).
+  - `POST /rbac/roles/{uuid}/permissions` — grant permissions additively; body `permission_uuids` (`roles.edit`).
+  - `PUT /rbac/roles/{uuid}/permissions` — replace/sync the full set; body `permission_uuids`, empty clears all (`roles.edit`).
+  - `DELETE /rbac/roles/{uuid}/permissions/{permission_uuid}` — revoke a single grant (`roles.edit`).
+
+  Each validates the role exists; the mutating routes audit the change via `logSecurityEvent`.
+
+### Changed
+- **Request bodies are now typed `RequestData` DTOs.** Every body-accepting endpoint across
+  `RoleController`, `PermissionController` and `UserRoleController` now declares a DTO parameter
+  (in `src/Http/DTOs/`) instead of reading `$request->toArray()` with inline `empty()` checks. The
+  router validates and hydrates the DTO before injection, so structural validation is declarative
+  and the OpenAPI generator reflects a typed request-body schema (and a documented `422`) for each.
+  Bonus hardening: actor/grantor fields (`assigned_by`, `granted_by`) are no longer DTO fields, so
+  they can only come from the authenticated identity — body spoofing is structurally impossible.
+
 ## [1.8.1] - 2026-06-20
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.8.1",
+            "version": "1.9.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -10,6 +10,13 @@ use Glueful\Extensions\Aegis\Services\AuditService;
 use Glueful\Extensions\Aegis\Repositories\PermissionRepository;
 use Glueful\Extensions\Aegis\Repositories\UserPermissionRepository;
 use Glueful\Extensions\Aegis\Http\Concerns\ResolvesActor;
+use Glueful\Extensions\Aegis\Http\DTOs\AssignPermissionToUserData;
+use Glueful\Extensions\Aegis\Http\DTOs\BatchAssignPermissionsData;
+use Glueful\Extensions\Aegis\Http\DTOs\BatchRevokePermissionsData;
+use Glueful\Extensions\Aegis\Http\DTOs\CheckPermissionData;
+use Glueful\Extensions\Aegis\Http\DTOs\CreatePermissionData;
+use Glueful\Extensions\Aegis\Http\DTOs\RevokePermissionFromUserData;
+use Glueful\Extensions\Aegis\Http\DTOs\UpdatePermissionData;
 use Glueful\Http\Exceptions\Client\NotFoundException;
 use Glueful\Routing\Attributes\ApiOperation;
 use Glueful\Routing\Attributes\ApiResponse;
@@ -142,19 +149,10 @@ class PermissionController
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(409, description: 'Permission name or slug already exists')]
-    public function create(Request $request): Response
+    public function create(CreatePermissionData $input, Request $request): Response
     {
         try {
-            $data = $request->toArray();
-
-            if (empty($data['name']) || empty($data['slug'])) {
-                return Response::validation(
-                    ['name' => ['Permission name is required'], 'slug' => ['Permission slug is required']],
-                    'Validation failed'
-                );
-            }
-
-            $permission = $this->permissionService->createPermission($data);
+            $permission = $this->permissionService->createPermission($input->toArray());
             if (!$permission) {
                 return Response::serverError('Failed to create permission');
             }
@@ -182,11 +180,11 @@ class PermissionController
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(404, description: 'Permission not found')]
-    public function update(Request $request): Response
+    public function update(UpdatePermissionData $input, Request $request): Response
     {
         try {
             $uuid = $request->attributes->get('uuid', '');
-            $data = $request->toArray();
+            $data = $input->toArray();
 
             $oldPermission = $this->permissionRepository->findRecordByUuid($uuid);
 
@@ -260,18 +258,10 @@ class PermissionController
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(404, description: 'Permission or user not found')]
-    public function assignToUser(Request $request): Response
+    public function assignToUser(AssignPermissionToUserData $input, Request $request): Response
     {
         try {
             $permissionUuid = $request->attributes->get('uuid', '');
-            $data = $request->toArray();
-
-            if (empty($data['user_uuid'])) {
-                return Response::validation(
-                    ['user_uuid' => ['User UUID is required']],
-                    'Validation failed'
-                );
-            }
 
             $permission = $this->permissionRepository->findRecordByUuid($permissionUuid);
             if (!$permission) {
@@ -279,15 +269,15 @@ class PermissionController
             }
 
             $actor = $this->actorUuid($request);
-            $resource = $data['resource'] ?? '*';
+            $resource = $input->resource;
             $options = [
                 'granted_by' => $actor,
-                'expires_at' => $data['expires_at'] ?? null,
-                'constraints' => $data['constraints'] ?? null
+                'expires_at' => $input->expires_at,
+                'constraints' => $input->constraints
             ];
 
             $assigned = $this->permissionService->assignPermissionToUser(
-                $data['user_uuid'],
+                $input->user_uuid,
                 $permission['slug'],
                 $resource,
                 $options
@@ -298,7 +288,7 @@ class PermissionController
             }
 
             $this->audit->logPermissionAssigned(
-                $data['user_uuid'],
+                $input->user_uuid,
                 $permissionUuid,
                 array_merge($options, ['resource' => $resource]),
                 $actor
@@ -327,18 +317,10 @@ class PermissionController
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(404, description: 'Permission or user not found')]
-    public function revokeFromUser(Request $request): Response
+    public function revokeFromUser(RevokePermissionFromUserData $input, Request $request): Response
     {
         try {
             $permissionUuid = $request->attributes->get('uuid', '');
-            $data = $request->toArray();
-
-            if (empty($data['user_uuid'])) {
-                return Response::validation(
-                    ['user_uuid' => ['User UUID is required']],
-                    'Validation failed'
-                );
-            }
 
             $permission = $this->permissionRepository->findRecordByUuid($permissionUuid);
             if (!$permission) {
@@ -346,12 +328,12 @@ class PermissionController
             }
 
             $revoked = $this->permissionService->revokePermissionFromUser(
-                $data['user_uuid'],
+                $input->user_uuid,
                 $permission['slug']
             );
 
             if ($revoked) {
-                $this->audit->logPermissionRevoked($data['user_uuid'], $permissionUuid, $this->actorUuid($request));
+                $this->audit->logPermissionRevoked($input->user_uuid, $permissionUuid, $this->actorUuid($request));
             }
 
             return Response::success(['revoked' => $revoked], 'Permission revocation processed');
@@ -375,22 +357,20 @@ class PermissionController
     #[ApiResponse(200, description: 'Batch permission assignment completed')]
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
-    public function batchAssign(Request $request): Response
+    public function batchAssign(BatchAssignPermissionsData $input, Request $request): Response
     {
         try {
-            $data = $request->toArray();
-
-            if (empty($data['user_uuid']) || empty($data['permissions'])) {
+            if ($input->permissions === []) {
                 return Response::validation(
-                    ['user_uuid' => ['User UUID is required'], 'permissions' => ['Permissions array is required']],
+                    ['permissions' => ['Permissions array is required']],
                     'Validation failed'
                 );
             }
 
             $actor = $this->actorUuid($request);
-            $globalOptions = array_merge($data['options'] ?? [], ['granted_by' => $actor]);
+            $globalOptions = array_merge($input->options, ['granted_by' => $actor]);
             $auditDataBySlug = [];
-            foreach ($data['permissions'] as $permissionData) {
+            foreach ($input->permissions as $permissionData) {
                 $slug = $permissionData['permission'] ?? '';
                 if ($slug === '') {
                     continue;
@@ -403,8 +383,8 @@ class PermissionController
             }
 
             $results = $this->permissionService->batchAssignPermissions(
-                $data['user_uuid'],
-                $data['permissions'],
+                $input->user_uuid,
+                $input->permissions,
                 $globalOptions
             );
 
@@ -419,7 +399,7 @@ class PermissionController
                 }
 
                 $this->audit->logPermissionAssigned(
-                    $data['user_uuid'],
+                    $input->user_uuid,
                     $permission->getUuid(),
                     $auditDataBySlug[$result['permission']] ?? ['resource' => $result['resource'] ?? '*'],
                     $actor
@@ -444,24 +424,19 @@ class PermissionController
     #[ApiResponse(200, description: 'Batch permission revocation completed')]
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
-    public function batchRevoke(Request $request): Response
+    public function batchRevoke(BatchRevokePermissionsData $input, Request $request): Response
     {
         try {
-            $data = $request->toArray();
-
-            if (empty($data['user_uuid']) || empty($data['permission_slugs'])) {
+            if ($input->permission_slugs === []) {
                 return Response::validation(
-                    [
-                        'user_uuid' => ['User UUID is required'],
-                        'permission_slugs' => ['Permission slugs array is required']
-                    ],
+                    ['permission_slugs' => ['Permission slugs array is required']],
                     'Validation failed'
                 );
             }
 
             $results = $this->permissionService->batchRevokePermissions(
-                $data['user_uuid'],
-                $data['permission_slugs']
+                $input->user_uuid,
+                $input->permission_slugs
             );
 
             $actor = $this->actorUuid($request);
@@ -475,7 +450,7 @@ class PermissionController
                     continue;
                 }
 
-                $this->audit->logPermissionRevoked($data['user_uuid'], $permission->getUuid(), $actor);
+                $this->audit->logPermissionRevoked($input->user_uuid, $permission->getUuid(), $actor);
             }
 
             return Response::success($results, 'Batch permission revocation completed');
@@ -558,30 +533,21 @@ class PermissionController
     #[ApiResponse(200, description: 'Permission check completed')]
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
-    public function checkPermission(Request $request): Response
+    public function checkPermission(CheckPermissionData $input, Request $request): Response
     {
         try {
-            $data = $request->toArray();
-
-            if (empty($data['user_uuid']) || empty($data['permission'])) {
-                return Response::validation(
-                    ['user_uuid' => ['User UUID is required'], 'permission' => ['Permission is required']],
-                    'Validation failed'
-                );
-            }
-
             $hasPermission = $this->permissionService->userHasPermission(
-                $data['user_uuid'],
-                $data['permission'],
-                $data['resource'] ?? '*',
-                $data['context'] ?? []
+                $input->user_uuid,
+                $input->permission,
+                $input->resource,
+                $input->context
             );
 
             return Response::success([
                 'has_permission' => $hasPermission,
-                'user_uuid' => $data['user_uuid'],
-                'permission' => $data['permission'],
-                'resource' => $data['resource'] ?? '*'
+                'user_uuid' => $input->user_uuid,
+                'permission' => $input->permission,
+                'resource' => $input->resource
             ], 'Permission check completed');
         } catch (\Exception $e) {
             return Response::serverError($e->getMessage());

--- a/src/Controllers/RoleController.php
+++ b/src/Controllers/RoleController.php
@@ -8,7 +8,14 @@ use Glueful\Http\Response;
 use Glueful\Extensions\Aegis\Services\RoleService;
 use Glueful\Extensions\Aegis\Services\AuditService;
 use Glueful\Extensions\Aegis\Repositories\RoleRepository;
+use Glueful\Extensions\Aegis\Repositories\RolePermissionRepository;
 use Glueful\Extensions\Aegis\Http\Concerns\ResolvesActor;
+use Glueful\Extensions\Aegis\Http\DTOs\AssignRoleToUserData;
+use Glueful\Extensions\Aegis\Http\DTOs\CreateRoleData;
+use Glueful\Extensions\Aegis\Http\DTOs\RoleBulkData;
+use Glueful\Extensions\Aegis\Http\DTOs\RolePermissionsData;
+use Glueful\Extensions\Aegis\Http\DTOs\RevokeRoleFromUserData;
+use Glueful\Extensions\Aegis\Http\DTOs\UpdateRoleData;
 use Glueful\Http\Exceptions\Client\NotFoundException;
 use Glueful\Routing\Attributes\ApiOperation;
 use Glueful\Routing\Attributes\ApiResponse;
@@ -30,15 +37,18 @@ class RoleController
 
     private RoleService $roleService;
     private RoleRepository $roleRepository;
+    private RolePermissionRepository $rolePermissions;
     private AuditService $audit;
 
     public function __construct(
         RoleService $roleService,
         RoleRepository $roleRepository,
+        RolePermissionRepository $rolePermissions,
         AuditService $audit
     ) {
         $this->roleService = $roleService;
         $this->roleRepository = $roleRepository;
+        $this->rolePermissions = $rolePermissions;
         $this->audit = $audit;
     }
 
@@ -148,19 +158,10 @@ class RoleController
     #[ApiResponse(400, description: 'Invalid request format or validation errors')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(409, description: 'Role name or slug already exists')]
-    public function create(Request $request): Response
+    public function create(CreateRoleData $input, Request $request): Response
     {
         try {
-            $data = $request->toArray();
-
-            if (empty($data['name']) || empty($data['slug'])) {
-                return Response::validation(
-                    ['name' => ['Role name is required'], 'slug' => ['Role slug is required']],
-                    'Validation failed'
-                );
-            }
-
-            $role = $this->roleService->createRole($data);
+            $role = $this->roleService->createRole($input->toArray());
             if (!$role) {
                 return Response::serverError('Failed to create role');
             }
@@ -188,11 +189,11 @@ class RoleController
     #[ApiResponse(400, description: 'Invalid request format or validation errors')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(404, description: 'Role not found')]
-    public function update(Request $request): Response
+    public function update(UpdateRoleData $input, Request $request): Response
     {
         try {
             $uuid = $request->attributes->get('uuid', '');
-            $data = $request->toArray();
+            $data = $input->toArray();
 
             $oldRole = $this->roleRepository->findRecordByUuid($uuid);
 
@@ -267,29 +268,24 @@ class RoleController
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(404, description: 'Role or user not found')]
-    public function assignToUser(Request $request): Response
+    public function assignToUser(AssignRoleToUserData $input, Request $request): Response
     {
         try {
             $roleUuid = $request->attributes->get('uuid', '');
-            $data = $request->toArray();
-
-            if (empty($data['user_uuid'])) {
-                return Response::validation(['user_uuid' => ['User UUID is required']], 'Validation failed');
-            }
 
             $actor = $this->actorUuid($request);
             $options = [
-                'scope' => $data['scope'] ?? [],
-                'expires_at' => $data['expires_at'] ?? null,
+                'scope' => $input->scope,
+                'expires_at' => $input->expires_at,
                 'assigned_by' => $actor,
             ];
 
-            $assigned = $this->roleService->assignRoleToUser($data['user_uuid'], $roleUuid, $options);
+            $assigned = $this->roleService->assignRoleToUser($input->user_uuid, $roleUuid, $options);
             if (!$assigned) {
                 return Response::serverError('Failed to assign role');
             }
 
-            $this->audit->logRoleAssigned($data['user_uuid'], $roleUuid, $options, $actor);
+            $this->audit->logRoleAssigned($input->user_uuid, $roleUuid, $options, $actor);
 
             return Response::success(null, 'Role assigned successfully');
         } catch (\InvalidArgumentException $e) {
@@ -312,22 +308,17 @@ class RoleController
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(404, description: 'Role or user not found')]
-    public function revokeFromUser(Request $request): Response
+    public function revokeFromUser(RevokeRoleFromUserData $input, Request $request): Response
     {
         try {
             $roleUuid = $request->attributes->get('uuid', '');
-            $data = $request->toArray();
 
-            if (empty($data['user_uuid'])) {
-                return Response::validation(['user_uuid' => ['User UUID is required']], 'Validation failed');
-            }
-
-            $revoked = $this->roleService->revokeRoleFromUser($data['user_uuid'], $roleUuid);
+            $revoked = $this->roleService->revokeRoleFromUser($input->user_uuid, $roleUuid);
             if (!$revoked) {
                 return Response::serverError('Failed to revoke role');
             }
 
-            $this->audit->logRoleRevoked($data['user_uuid'], $roleUuid, $this->actorUuid($request));
+            $this->audit->logRoleRevoked($input->user_uuid, $roleUuid, $this->actorUuid($request));
 
             return Response::success(null, 'Role revoked successfully');
         } catch (\Exception $e) {
@@ -369,6 +360,163 @@ class RoleController
             return Response::successWithMeta($usersData, $meta, 'Role users retrieved successfully');
         } catch (NotFoundException $e) {
             return Response::notFound($e->getMessage());
+        } catch (\Exception $e) {
+            return Response::serverError($e->getMessage());
+        }
+    }
+
+    /**
+     * List the permissions granted to a role.
+     */
+    #[ApiOperation(
+        summary: 'List role permissions',
+        description: 'Retrieves the permission grants for a role. Requires the `roles.view` permission.',
+        tags: ['RBAC Roles'],
+    )]
+    #[ApiResponse(200, description: 'Role permissions retrieved successfully')]
+    #[ApiResponse(403, description: 'Permission denied')]
+    #[ApiResponse(404, description: 'Role not found')]
+    public function getPermissions(Request $request): Response
+    {
+        try {
+            $uuid = $request->attributes->get('uuid', '');
+            if (!$this->roleRepository->findRecordByUuid($uuid)) {
+                return Response::notFound('Role not found.');
+            }
+
+            $permissions = $this->rolePermissions->getRolePermissions($uuid);
+
+            return Response::success(
+                ['permissions' => $permissions],
+                'Role permissions retrieved successfully'
+            );
+        } catch (\Exception $e) {
+            return Response::serverError($e->getMessage());
+        }
+    }
+
+    /**
+     * Assign permissions to a role (additive).
+     */
+    #[ApiOperation(
+        summary: 'Assign permissions to role',
+        description: 'Grants one or more permissions to a role without removing existing grants. '
+            . 'Body: `permission_uuids` (required array). Requires the `roles.edit` permission.',
+        tags: ['RBAC Roles'],
+    )]
+    #[ApiResponse(200, description: 'Permissions assigned to role successfully')]
+    #[ApiResponse(400, description: 'Invalid request format')]
+    #[ApiResponse(403, description: 'Permission denied')]
+    #[ApiResponse(404, description: 'Role not found')]
+    public function assignPermissions(RolePermissionsData $input, Request $request): Response
+    {
+        try {
+            $uuid = $request->attributes->get('uuid', '');
+
+            if ($input->permission_uuids === []) {
+                return Response::validation(
+                    ['permission_uuids' => ['At least one permission UUID is required']],
+                    'Validation failed'
+                );
+            }
+            if (!$this->roleRepository->findRecordByUuid($uuid)) {
+                return Response::notFound('Role not found.');
+            }
+
+            $results = $this->rolePermissions->batchAssignPermissions($uuid, $input->permission_uuids);
+
+            $this->audit->logSecurityEvent(
+                'role.permissions.assigned',
+                ['role_uuid' => $uuid, 'permission_uuids' => $input->permission_uuids],
+                $this->actorUuid($request)
+            );
+
+            return Response::success($results, 'Permissions assigned to role successfully');
+        } catch (\InvalidArgumentException $e) {
+            return Response::validation(['error' => [$e->getMessage()]], 'Validation failed');
+        } catch (\Exception $e) {
+            return Response::serverError($e->getMessage());
+        }
+    }
+
+    /**
+     * Replace (sync) the full set of a role's permissions.
+     */
+    #[ApiOperation(
+        summary: 'Replace role permissions',
+        description: 'Replaces the role\'s permissions with exactly the supplied set (grants the '
+            . 'missing ones, revokes the rest). Body: `permission_uuids` (required array; empty clears '
+            . 'all). Requires the `roles.edit` permission.',
+        tags: ['RBAC Roles'],
+    )]
+    #[ApiResponse(200, description: 'Role permissions updated successfully')]
+    #[ApiResponse(400, description: 'Invalid request format')]
+    #[ApiResponse(403, description: 'Permission denied')]
+    #[ApiResponse(404, description: 'Role not found')]
+    public function replacePermissions(RolePermissionsData $input, Request $request): Response
+    {
+        try {
+            $uuid = $request->attributes->get('uuid', '');
+
+            if (!$this->roleRepository->findRecordByUuid($uuid)) {
+                return Response::notFound('Role not found.');
+            }
+
+            $ok = $this->rolePermissions->replaceRolePermissions($uuid, $input->permission_uuids);
+            if (!$ok) {
+                return Response::serverError('Failed to update role permissions');
+            }
+
+            $this->audit->logSecurityEvent(
+                'role.permissions.replaced',
+                ['role_uuid' => $uuid, 'permission_uuids' => $input->permission_uuids],
+                $this->actorUuid($request)
+            );
+
+            return Response::success(
+                ['permissions' => $this->rolePermissions->getRolePermissions($uuid)],
+                'Role permissions updated successfully'
+            );
+        } catch (\InvalidArgumentException $e) {
+            return Response::validation(['error' => [$e->getMessage()]], 'Validation failed');
+        } catch (\Exception $e) {
+            return Response::serverError($e->getMessage());
+        }
+    }
+
+    /**
+     * Revoke a single permission from a role.
+     */
+    #[ApiOperation(
+        summary: 'Revoke permission from role',
+        description: 'Removes a single permission grant from a role. Requires the `roles.edit` permission.',
+        tags: ['RBAC Roles'],
+    )]
+    #[ApiResponse(200, description: 'Permission revoked from role successfully')]
+    #[ApiResponse(403, description: 'Permission denied')]
+    #[ApiResponse(404, description: 'Role not found')]
+    public function revokePermission(Request $request): Response
+    {
+        try {
+            $uuid = $request->attributes->get('uuid', '');
+            $permissionUuid = $request->attributes->get('permission_uuid', '');
+
+            if (!$this->roleRepository->findRecordByUuid($uuid)) {
+                return Response::notFound('Role not found.');
+            }
+
+            $revoked = $this->rolePermissions->revokePermissionFromRole($uuid, $permissionUuid);
+            if (!$revoked) {
+                return Response::serverError('Failed to revoke permission from role');
+            }
+
+            $this->audit->logSecurityEvent(
+                'role.permissions.revoked',
+                ['role_uuid' => $uuid, 'permission_uuid' => $permissionUuid],
+                $this->actorUuid($request)
+            );
+
+            return Response::success(null, 'Permission revoked from role successfully');
         } catch (\Exception $e) {
             return Response::serverError($e->getMessage());
         }
@@ -431,14 +579,12 @@ class RoleController
     #[ApiResponse(200, description: 'Bulk operation completed')]
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
-    public function bulk(Request $request): Response
+    public function bulk(RoleBulkData $input, Request $request): Response
     {
         try {
-            $data = $request->toArray();
-
-            if (empty($data['action']) || empty($data['role_ids'])) {
+            if ($input->role_ids === []) {
                 return Response::validation(
-                    ['action' => ['Action is required'], 'role_ids' => ['Role IDs are required']],
+                    ['role_ids' => ['Role IDs are required']],
                     'Validation failed'
                 );
             }
@@ -450,7 +596,7 @@ class RoleController
             ];
 
             $actor = $this->actorUuid($request);
-            foreach ($data['role_ids'] as $roleUuid) {
+            foreach ($input->role_ids as $roleUuid) {
                 try {
                     $role = $this->roleRepository->findRecordByUuid($roleUuid);
                     if (!$role) {
@@ -459,9 +605,9 @@ class RoleController
                         continue;
                     }
 
-                    switch ($data['action']) {
+                    switch ($input->action) {
                         case 'delete':
-                            $force = $data['force'] ?? false;
+                            $force = $input->force;
                             if (!$this->roleService->deleteRole($roleUuid, $force)) {
                                 throw new \RuntimeException('Delete failed');
                             }

--- a/src/Controllers/UserRoleController.php
+++ b/src/Controllers/UserRoleController.php
@@ -10,6 +10,9 @@ use Glueful\Extensions\Aegis\Services\PermissionAssignmentService;
 use Glueful\Extensions\Aegis\Services\AuditService;
 use Glueful\Extensions\Aegis\Repositories\UserRoleRepository;
 use Glueful\Extensions\Aegis\Http\Concerns\ResolvesActor;
+use Glueful\Extensions\Aegis\Http\DTOs\BulkRoleUsersData;
+use Glueful\Extensions\Aegis\Http\DTOs\CheckUserRoleData;
+use Glueful\Extensions\Aegis\Http\DTOs\UserRolesData;
 use Glueful\Routing\Attributes\ApiOperation;
 use Glueful\Routing\Attributes\ApiResponse;
 use Glueful\Routing\Attributes\QueryParam;
@@ -89,13 +92,12 @@ class UserRoleController
     #[ApiResponse(200, description: 'Roles assigned successfully')]
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
-    public function assignRoles(Request $request): Response
+    public function assignRoles(UserRolesData $input, Request $request): Response
     {
         try {
             $userUuid = $request->attributes->get('user_uuid', '');
-            $data = $request->toArray();
 
-            if (empty($data['role_uuids'])) {
+            if ($input->role_uuids === []) {
                 return Response::validation(
                     ['role_uuids' => ['Role UUIDs array is required']],
                     'Validation failed'
@@ -110,12 +112,12 @@ class UserRoleController
 
             $actor = $this->actorUuid($request);
             $options = [
-                'scope' => $data['scope'] ?? [],
-                'expires_at' => $data['expires_at'] ?? null,
+                'scope' => $input->scope,
+                'expires_at' => $input->expires_at,
                 'assigned_by' => $actor,
             ];
 
-            foreach ($data['role_uuids'] as $roleUuid) {
+            foreach ($input->role_uuids as $roleUuid) {
                 try {
                     $assigned = $this->roleService->assignRoleToUser($userUuid, $roleUuid, $options);
                     if ($assigned) {
@@ -182,20 +184,12 @@ class UserRoleController
     #[ApiResponse(200, description: 'User roles updated successfully')]
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
-    public function replaceUserRoles(Request $request): Response
+    public function replaceUserRoles(UserRolesData $input, Request $request): Response
     {
         try {
             $userUuid = $request->attributes->get('user_uuid', '');
-            $data = $request->toArray();
 
-            if (!isset($data['role_uuids']) || !is_array($data['role_uuids'])) {
-                return Response::validation(
-                    ['role_uuids' => ['Role UUIDs array is required']],
-                    'Validation failed'
-                );
-            }
-
-            $scope = $data['scope'] ?? [];
+            $scope = $input->scope;
             $currentRoles = $this->roleService->getUserRoles($userUuid, $scope);
             $currentRoleUuids = array_column(array_column($currentRoles, 'role'), 'uuid');
 
@@ -208,13 +202,13 @@ class UserRoleController
             $actor = $this->actorUuid($request);
             $options = [
                 'scope' => $scope,
-                'expires_at' => $data['expires_at'] ?? null,
+                'expires_at' => $input->expires_at,
                 'assigned_by' => $actor,
             ];
 
             // Remove roles that are no longer assigned
             foreach ($currentRoleUuids as $currentRoleUuid) {
-                if (!in_array($currentRoleUuid, $data['role_uuids'])) {
+                if (!in_array($currentRoleUuid, $input->role_uuids)) {
                     try {
                         $this->roleService->revokeRoleFromUser($userUuid, $currentRoleUuid);
                         $results['removed']++;
@@ -226,7 +220,7 @@ class UserRoleController
             }
 
             // Add new roles
-            foreach ($data['role_uuids'] as $roleUuid) {
+            foreach ($input->role_uuids as $roleUuid) {
                 if (!in_array($roleUuid, $currentRoleUuids)) {
                     try {
                         $this->roleService->assignRoleToUser($userUuid, $roleUuid, $options);
@@ -259,26 +253,18 @@ class UserRoleController
     #[ApiResponse(200, description: 'Role check completed')]
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
-    public function checkUserRole(Request $request): Response
+    public function checkUserRole(CheckUserRoleData $input, Request $request): Response
     {
         try {
             $userUuid = $request->attributes->get('user_uuid', '');
-            $data = $request->toArray();
 
-            if (empty($data['role_slug'])) {
-                return Response::validation(
-                    ['role_slug' => ['Role slug is required']],
-                    'Validation failed'
-                );
-            }
-
-            $scope = $data['scope'] ?? [];
-            $hasRole = $this->roleService->userHasRole($userUuid, $data['role_slug'], $scope);
+            $scope = $input->scope;
+            $hasRole = $this->roleService->userHasRole($userUuid, $input->role_slug, $scope);
 
             return Response::success([
                 'has_role' => $hasRole,
                 'user_uuid' => $userUuid,
-                'role_slug' => $data['role_slug'],
+                'role_slug' => $input->role_slug,
                 'scope' => $scope
             ], 'Role check completed');
         } catch (\Exception $e) {
@@ -376,13 +362,12 @@ class UserRoleController
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(404, description: 'Role not found')]
-    public function bulkAssignRoleToUsers(Request $request): Response
+    public function bulkAssignRoleToUsers(BulkRoleUsersData $input, Request $request): Response
     {
         try {
             $roleUuid = $request->attributes->get('role_uuid', '');
-            $data = $request->toArray();
 
-            if (empty($data['user_uuids'])) {
+            if ($input->user_uuids === []) {
                 return Response::validation(
                     ['user_uuids' => ['User UUIDs array is required']],
                     'Validation failed'
@@ -397,12 +382,12 @@ class UserRoleController
 
             $actor = $this->actorUuid($request);
             $options = [
-                'scope' => $data['scope'] ?? [],
-                'expires_at' => $data['expires_at'] ?? null,
+                'scope' => $input->scope,
+                'expires_at' => $input->expires_at,
                 'assigned_by' => $actor,
             ];
 
-            foreach ($data['user_uuids'] as $userUuid) {
+            foreach ($input->user_uuids as $userUuid) {
                 try {
                     $assigned = $this->roleService->assignRoleToUser($userUuid, $roleUuid, $options);
                     if ($assigned) {
@@ -440,13 +425,12 @@ class UserRoleController
     #[ApiResponse(400, description: 'Invalid request format')]
     #[ApiResponse(403, description: 'Permission denied')]
     #[ApiResponse(404, description: 'Role not found')]
-    public function bulkRevokeRoleFromUsers(Request $request): Response
+    public function bulkRevokeRoleFromUsers(BulkRoleUsersData $input, Request $request): Response
     {
         try {
             $roleUuid = $request->attributes->get('role_uuid', '');
-            $data = $request->toArray();
 
-            if (empty($data['user_uuids'])) {
+            if ($input->user_uuids === []) {
                 return Response::validation(
                     ['user_uuids' => ['User UUIDs array is required']],
                     'Validation failed'
@@ -460,7 +444,7 @@ class UserRoleController
             ];
 
             $actor = $this->actorUuid($request);
-            foreach ($data['user_uuids'] as $userUuid) {
+            foreach ($input->user_uuids as $userUuid) {
                 try {
                     $revoked = $this->roleService->revokeRoleFromUser($userUuid, $roleUuid);
                     if ($revoked) {

--- a/src/Http/DTOs/AssignPermissionToUserData.php
+++ b/src/Http/DTOs/AssignPermissionToUserData.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `POST /rbac/permissions/{uuid}/assign`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\PermissionController::assignToUser()}). The grantor
+ * is taken from the authenticated identity, never the body.
+ */
+final class AssignPermissionToUserData implements RequestData
+{
+    /** @param array<string,mixed>|null $constraints */
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $user_uuid,
+        #[Rule('string')]
+        public readonly string $resource = '*',
+        #[Rule('string')]
+        public readonly ?string $expires_at = null,
+        #[Rule('array')]
+        public readonly ?array $constraints = null,
+    ) {
+    }
+}

--- a/src/Http/DTOs/AssignRoleToUserData.php
+++ b/src/Http/DTOs/AssignRoleToUserData.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `POST /rbac/roles/{uuid}/assign`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\RoleController::assignToUser()}). The actor
+ * (`assigned_by`) is taken from the authenticated identity, never the body.
+ */
+final class AssignRoleToUserData implements RequestData
+{
+    /** @param array<string,mixed> $scope */
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $user_uuid,
+        #[Rule('array')]
+        public readonly array $scope = [],
+        #[Rule('string')]
+        public readonly ?string $expires_at = null,
+    ) {
+    }
+}

--- a/src/Http/DTOs/BatchAssignPermissionsData.php
+++ b/src/Http/DTOs/BatchAssignPermissionsData.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `POST /rbac/permissions/batch-assign`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\PermissionController::batchAssign()}).
+ */
+final class BatchAssignPermissionsData implements RequestData
+{
+    /**
+     * @param list<array<string,mixed>> $permissions  Each: {permission, resource, options}.
+     * @param array<string,mixed>       $options       Shared options merged into each grant.
+     */
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $user_uuid,
+        #[Rule('required|array')]
+        public readonly array $permissions = [],
+        #[Rule('array')]
+        public readonly array $options = [],
+    ) {
+    }
+}

--- a/src/Http/DTOs/BatchRevokePermissionsData.php
+++ b/src/Http/DTOs/BatchRevokePermissionsData.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\ArrayOf;
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `POST /rbac/permissions/batch-revoke`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\PermissionController::batchRevoke()}).
+ */
+final class BatchRevokePermissionsData implements RequestData
+{
+    /** @param list<string> $permission_slugs */
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $user_uuid,
+        #[ArrayOf('string')]
+        #[Rule('required|array')]
+        public readonly array $permission_slugs = [],
+    ) {
+    }
+}

--- a/src/Http/DTOs/BulkRoleUsersData.php
+++ b/src/Http/DTOs/BulkRoleUsersData.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\ArrayOf;
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for bulk-assigning/revoking a role across users
+ * (`POST /rbac/roles/{role_uuid}/assign-users`, `DELETE /rbac/roles/{role_uuid}/revoke-users`).
+ * A non-empty `user_uuids` is enforced in the controller.
+ */
+final class BulkRoleUsersData implements RequestData
+{
+    /**
+     * @param list<string>        $user_uuids
+     * @param array<string,mixed> $scope
+     */
+    public function __construct(
+        #[ArrayOf('string')]
+        #[Rule('array')]
+        public readonly array $user_uuids = [],
+        #[Rule('array')]
+        public readonly array $scope = [],
+        #[Rule('string')]
+        public readonly ?string $expires_at = null,
+    ) {
+    }
+}

--- a/src/Http/DTOs/CheckPermissionData.php
+++ b/src/Http/DTOs/CheckPermissionData.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `POST /rbac/check-permission`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\PermissionController::checkPermission()}).
+ */
+final class CheckPermissionData implements RequestData
+{
+    /** @param array<string,mixed> $context */
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $user_uuid,
+        #[Rule('required|string')]
+        public readonly string $permission,
+        #[Rule('string')]
+        public readonly string $resource = '*',
+        #[Rule('array')]
+        public readonly array $context = [],
+    ) {
+    }
+}

--- a/src/Http/DTOs/CheckUserRoleData.php
+++ b/src/Http/DTOs/CheckUserRoleData.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `POST /rbac/users/{user_uuid}/check-role`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\UserRoleController::checkUserRole()}).
+ */
+final class CheckUserRoleData implements RequestData
+{
+    /** @param array<string,mixed> $scope */
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $role_slug,
+        #[Rule('array')]
+        public readonly array $scope = [],
+    ) {
+    }
+}

--- a/src/Http/DTOs/CreatePermissionData.php
+++ b/src/Http/DTOs/CreatePermissionData.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `POST /rbac/permissions`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\PermissionController::create()}).
+ */
+final class CreatePermissionData implements RequestData
+{
+    /** @param array<string,mixed>|null $metadata */
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $name,
+        #[Rule('required|string')]
+        public readonly string $slug,
+        #[Rule('string')]
+        public readonly ?string $description = null,
+        #[Rule('string')]
+        public readonly ?string $category = null,
+        #[Rule('string')]
+        public readonly ?string $resource_type = null,
+        #[Rule('array')]
+        public readonly ?array $metadata = null,
+    ) {
+    }
+
+    /** @return array<string,mixed> */
+    public function toArray(): array
+    {
+        return array_filter(
+            [
+                'name' => $this->name,
+                'slug' => $this->slug,
+                'description' => $this->description,
+                'category' => $this->category,
+                'resource_type' => $this->resource_type,
+                'metadata' => $this->metadata,
+            ],
+            static fn($v): bool => $v !== null,
+        );
+    }
+}

--- a/src/Http/DTOs/CreateRoleData.php
+++ b/src/Http/DTOs/CreateRoleData.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `POST /rbac/roles` ({@see \Glueful\Extensions\Aegis\Controllers\RoleController::create()}).
+ *
+ * Structural validation (required name/slug, field types) runs here via the hydrated DTO; the
+ * duplicate name/slug and parent-cycle checks stay in {@see \Glueful\Extensions\Aegis\Services\RoleService}.
+ */
+final class CreateRoleData implements RequestData
+{
+    /** @param array<string,mixed>|null $metadata */
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $name,
+        #[Rule('required|string')]
+        public readonly string $slug,
+        #[Rule('string')]
+        public readonly ?string $description = null,
+        #[Rule('string')]
+        public readonly ?string $parent_uuid = null,
+        #[Rule('numeric')]
+        public readonly ?int $level = null,
+        #[Rule('string')]
+        public readonly ?string $status = null,
+        #[Rule('array')]
+        public readonly ?array $metadata = null,
+    ) {
+    }
+
+    /**
+     * The non-null fields as the array {@see RoleService::createRole()} consumes.
+     *
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter(
+            [
+                'name' => $this->name,
+                'slug' => $this->slug,
+                'description' => $this->description,
+                'parent_uuid' => $this->parent_uuid,
+                'level' => $this->level,
+                'status' => $this->status,
+                'metadata' => $this->metadata,
+            ],
+            static fn($v): bool => $v !== null,
+        );
+    }
+}

--- a/src/Http/DTOs/RevokePermissionFromUserData.php
+++ b/src/Http/DTOs/RevokePermissionFromUserData.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `DELETE /rbac/permissions/{uuid}/revoke`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\PermissionController::revokeFromUser()}).
+ */
+final class RevokePermissionFromUserData implements RequestData
+{
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $user_uuid,
+    ) {
+    }
+}

--- a/src/Http/DTOs/RevokeRoleFromUserData.php
+++ b/src/Http/DTOs/RevokeRoleFromUserData.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `DELETE /rbac/roles/{uuid}/revoke`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\RoleController::revokeFromUser()}).
+ */
+final class RevokeRoleFromUserData implements RequestData
+{
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $user_uuid,
+    ) {
+    }
+}

--- a/src/Http/DTOs/RoleBulkData.php
+++ b/src/Http/DTOs/RoleBulkData.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\ArrayOf;
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `POST /rbac/roles/bulk`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\RoleController::bulk()}).
+ */
+final class RoleBulkData implements RequestData
+{
+    /** @param list<string> $role_ids */
+    public function __construct(
+        #[Rule('required|string')]
+        public readonly string $action,
+        #[ArrayOf('string')]
+        #[Rule('required|array')]
+        public readonly array $role_ids = [],
+        #[Rule('boolean')]
+        public readonly bool $force = false,
+    ) {
+    }
+}

--- a/src/Http/DTOs/RolePermissionsData.php
+++ b/src/Http/DTOs/RolePermissionsData.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\ArrayOf;
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for the role↔permission endpoints
+ * (`POST`/`PUT /rbac/roles/{uuid}/permissions`). `POST` (assign) requires a non-empty set —
+ * enforced in the controller; `PUT` (replace) accepts an empty array to clear all grants.
+ */
+final class RolePermissionsData implements RequestData
+{
+    /** @param list<string> $permission_uuids */
+    public function __construct(
+        #[ArrayOf('string')]
+        #[Rule('array')]
+        public readonly array $permission_uuids = [],
+    ) {
+    }
+}

--- a/src/Http/DTOs/UpdatePermissionData.php
+++ b/src/Http/DTOs/UpdatePermissionData.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `PUT /rbac/permissions/{uuid}`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\PermissionController::update()}). All optional.
+ */
+final class UpdatePermissionData implements RequestData
+{
+    /** @param array<string,mixed>|null $metadata */
+    public function __construct(
+        #[Rule('string')]
+        public readonly ?string $name = null,
+        #[Rule('string')]
+        public readonly ?string $description = null,
+        #[Rule('string')]
+        public readonly ?string $category = null,
+        #[Rule('array')]
+        public readonly ?array $metadata = null,
+    ) {
+    }
+
+    /** @return array<string,mixed> */
+    public function toArray(): array
+    {
+        return array_filter(
+            [
+                'name' => $this->name,
+                'description' => $this->description,
+                'category' => $this->category,
+                'metadata' => $this->metadata,
+            ],
+            static fn($v): bool => $v !== null,
+        );
+    }
+}

--- a/src/Http/DTOs/UpdateRoleData.php
+++ b/src/Http/DTOs/UpdateRoleData.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for `PUT /rbac/roles/{uuid}`
+ * ({@see \Glueful\Extensions\Aegis\Controllers\RoleController::update()}). All fields optional;
+ * only the supplied ones are changed.
+ */
+final class UpdateRoleData implements RequestData
+{
+    /** @param array<string,mixed>|null $metadata */
+    public function __construct(
+        #[Rule('string')]
+        public readonly ?string $name = null,
+        #[Rule('string')]
+        public readonly ?string $description = null,
+        #[Rule('string')]
+        public readonly ?string $parent_uuid = null,
+        #[Rule('string')]
+        public readonly ?string $status = null,
+        #[Rule('array')]
+        public readonly ?array $metadata = null,
+    ) {
+    }
+
+    /**
+     * Only the explicitly-supplied (non-null) fields, so unset fields are left unchanged.
+     *
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter(
+            [
+                'name' => $this->name,
+                'description' => $this->description,
+                'parent_uuid' => $this->parent_uuid,
+                'status' => $this->status,
+                'metadata' => $this->metadata,
+            ],
+            static fn($v): bool => $v !== null,
+        );
+    }
+}

--- a/src/Http/DTOs/UserRolesData.php
+++ b/src/Http/DTOs/UserRolesData.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\DTOs;
+
+use Glueful\Validation\Attributes\ArrayOf;
+use Glueful\Validation\Attributes\Rule;
+use Glueful\Validation\Contracts\RequestData;
+
+/**
+ * Request body for assigning/replacing a user's roles
+ * (`POST`/`PUT /rbac/users/{user_uuid}/roles`). `POST` (assign) requires a non-empty set —
+ * enforced in the controller; `PUT` (replace) accepts an empty array to clear all roles.
+ */
+final class UserRolesData implements RequestData
+{
+    /**
+     * @param list<string>        $role_uuids
+     * @param array<string,mixed> $scope
+     */
+    public function __construct(
+        #[ArrayOf('string')]
+        #[Rule('array')]
+        public readonly array $role_uuids = [],
+        #[Rule('array')]
+        public readonly array $scope = [],
+        #[Rule('string')]
+        public readonly ?string $expires_at = null,
+    ) {
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -45,6 +45,11 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
         $router->get('/{uuid}/users', [RoleController::class, 'getUsers'])->middleware('aegis_permission:roles.view');
         $router->post('/{role_uuid}/assign-users', [UserRoleController::class, 'bulkAssignRoleToUsers'])->middleware('aegis_permission:roles.assign');
         $router->delete('/{role_uuid}/revoke-users', [UserRoleController::class, 'bulkRevokeRoleFromUsers'])->middleware('aegis_permission:roles.assign');
+        // Role ↔ permission grants.
+        $router->get('/{uuid}/permissions', [RoleController::class, 'getPermissions'])->middleware('aegis_permission:roles.view');
+        $router->post('/{uuid}/permissions', [RoleController::class, 'assignPermissions'])->middleware('aegis_permission:roles.edit');
+        $router->put('/{uuid}/permissions', [RoleController::class, 'replacePermissions'])->middleware('aegis_permission:roles.edit');
+        $router->delete('/{uuid}/permissions/{permission_uuid}', [RoleController::class, 'revokePermission'])->middleware('aegis_permission:roles.edit');
     });
 
     // Permission Management Routes

--- a/tests/Unit/AuditActorAttributionTest.php
+++ b/tests/Unit/AuditActorAttributionTest.php
@@ -7,8 +7,13 @@ namespace Glueful\Extensions\Aegis\Tests\Unit;
 use Glueful\Auth\UserIdentity;
 use Glueful\Extensions\Aegis\Controllers\PermissionController;
 use Glueful\Extensions\Aegis\Controllers\RoleController;
+use Glueful\Extensions\Aegis\Http\DTOs\AssignRoleToUserData;
+use Glueful\Extensions\Aegis\Http\DTOs\BatchAssignPermissionsData;
+use Glueful\Extensions\Aegis\Http\DTOs\BatchRevokePermissionsData;
+use Glueful\Extensions\Aegis\Http\DTOs\RoleBulkData;
 use Glueful\Extensions\Aegis\Models\Permission;
 use Glueful\Extensions\Aegis\Repositories\RoleRepository;
+use Glueful\Extensions\Aegis\Repositories\RolePermissionRepository;
 use Glueful\Extensions\Aegis\Repositories\PermissionRepository;
 use Glueful\Extensions\Aegis\Repositories\UserPermissionRepository;
 use Glueful\Extensions\Aegis\Services\AuditService;
@@ -41,22 +46,19 @@ final class AuditActorAttributionTest extends TestCase
             ->method('logRoleAssigned')
             ->with('target-user', 'role-1', self::anything(), 'real-admin');
 
-        $controller = new RoleController($roleService, $this->createMock(RoleRepository::class), $audit);
-
-        // Body tries to forge assigned_by; it must be ignored in favour of auth.user.
-        $request = Request::create(
-            '/x',
-            'POST',
-            [],
-            [],
-            [],
-            [],
-            (string) json_encode(['user_uuid' => 'target-user', 'assigned_by' => 'spoofed-attacker'])
+        $controller = new RoleController(
+            $roleService,
+            $this->createMock(RoleRepository::class),
+            $this->createMock(RolePermissionRepository::class),
+            $audit
         );
+
+        // The DTO has no `assigned_by` field, so the actor can only come from auth.user.
+        $request = Request::create('/x', 'POST');
         $request->attributes->set('uuid', 'role-1');
         $request->attributes->set('auth.user', new UserIdentity('real-admin', ['administrator']));
 
-        $response = $controller->assignToUser($request);
+        $response = $controller->assignToUser(new AssignRoleToUserData(user_uuid: 'target-user'), $request);
 
         self::assertSame(200, $response->getStatusCode());
     }
@@ -103,13 +105,14 @@ final class AuditActorAttributionTest extends TestCase
             $audit
         );
 
-        $request = $this->jsonRequest([
-            'user_uuid' => 'target-user',
-            'permissions' => [['permission' => 'posts.edit', 'resource' => 'posts:1']],
-            'options' => ['granted_by' => 'spoofed-attacker'],
-        ]);
+        // options.granted_by tries to forge the grantor; the controller overrides it with auth.user.
+        $input = new BatchAssignPermissionsData(
+            user_uuid: 'target-user',
+            permissions: [['permission' => 'posts.edit', 'resource' => 'posts:1']],
+            options: ['granted_by' => 'spoofed-attacker'],
+        );
 
-        $response = $controller->batchAssign($request);
+        $response = $controller->batchAssign($input, $this->jsonRequest([]));
 
         self::assertSame(200, $response->getStatusCode());
     }
@@ -147,12 +150,9 @@ final class AuditActorAttributionTest extends TestCase
             $audit
         );
 
-        $request = $this->jsonRequest([
-            'user_uuid' => 'target-user',
-            'permission_slugs' => ['posts.edit'],
-        ]);
+        $input = new BatchRevokePermissionsData(user_uuid: 'target-user', permission_slugs: ['posts.edit']);
 
-        $response = $controller->batchRevoke($request);
+        $response = $controller->batchRevoke($input, $this->jsonRequest([]));
 
         self::assertSame(200, $response->getStatusCode());
     }
@@ -176,8 +176,16 @@ final class AuditActorAttributionTest extends TestCase
             ->method('logRoleDeleted')
             ->with('role-1', ['uuid' => 'role-1', 'slug' => 'editor'], 'real-admin');
 
-        $controller = new RoleController($roleService, $roles, $audit);
-        $response = $controller->bulk($this->jsonRequest(['action' => 'delete', 'role_ids' => ['role-1']]));
+        $controller = new RoleController(
+            $roleService,
+            $roles,
+            $this->createMock(RolePermissionRepository::class),
+            $audit
+        );
+        $response = $controller->bulk(
+            new RoleBulkData(action: 'delete', role_ids: ['role-1']),
+            $this->jsonRequest([])
+        );
 
         self::assertSame(200, $response->getStatusCode());
     }
@@ -209,8 +217,16 @@ final class AuditActorAttributionTest extends TestCase
                 'real-admin'
             );
 
-        $controller = new RoleController($roleService, $roles, $audit);
-        $response = $controller->bulk($this->jsonRequest(['action' => 'deactivate', 'role_ids' => ['role-1']]));
+        $controller = new RoleController(
+            $roleService,
+            $roles,
+            $this->createMock(RolePermissionRepository::class),
+            $audit
+        );
+        $response = $controller->bulk(
+            new RoleBulkData(action: 'deactivate', role_ids: ['role-1']),
+            $this->jsonRequest([])
+        );
 
         self::assertSame(200, $response->getStatusCode());
     }

--- a/tests/Unit/RolePermissionEndpointsTest.php
+++ b/tests/Unit/RolePermissionEndpointsTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Tests\Unit;
+
+use Glueful\Auth\UserIdentity;
+use Glueful\Extensions\Aegis\Controllers\RoleController;
+use Glueful\Extensions\Aegis\Http\DTOs\RolePermissionsData;
+use Glueful\Extensions\Aegis\Repositories\RolePermissionRepository;
+use Glueful\Extensions\Aegis\Repositories\RoleRepository;
+use Glueful\Extensions\Aegis\Services\AuditService;
+use Glueful\Extensions\Aegis\Services\RoleService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The role↔permission endpoints wire RolePermissionRepository to HTTP: read a role's grants, add,
+ * replace (sync), and revoke. Each validates the role exists and a well-formed body, and the
+ * mutating ones audit the change.
+ */
+final class RolePermissionEndpointsTest extends TestCase
+{
+    public function test_get_permissions_returns_role_grants(): void
+    {
+        $roles = $this->createMock(RoleRepository::class);
+        $roles->method('findRecordByUuid')->with('role-1')->willReturn(['uuid' => 'role-1']);
+        $rp = $this->createMock(RolePermissionRepository::class);
+        $rp->expects(self::once())
+            ->method('getRolePermissions')
+            ->with('role-1')
+            ->willReturn([['permission_uuid' => 'perm-1']]);
+
+        $response = $this->controller($roles, $rp)->getPermissions($this->request('role-1'));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_get_permissions_404_when_role_missing(): void
+    {
+        $roles = $this->createMock(RoleRepository::class);
+        $roles->method('findRecordByUuid')->willReturn(null);
+        $rp = $this->createMock(RolePermissionRepository::class);
+        $rp->expects(self::never())->method('getRolePermissions');
+
+        $response = $this->controller($roles, $rp)->getPermissions($this->request('missing'));
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function test_assign_permissions_rejects_missing_array(): void
+    {
+        $roles = $this->createMock(RoleRepository::class);
+        $rp = $this->createMock(RolePermissionRepository::class);
+        $rp->expects(self::never())->method('batchAssignPermissions');
+
+        $response = $this->controller($roles, $rp)
+            ->assignPermissions(new RolePermissionsData([]), $this->request('role-1'));
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function test_assign_permissions_batch_assigns_and_audits(): void
+    {
+        $roles = $this->createMock(RoleRepository::class);
+        $roles->method('findRecordByUuid')->willReturn(['uuid' => 'role-1']);
+        $rp = $this->createMock(RolePermissionRepository::class);
+        $rp->expects(self::once())
+            ->method('batchAssignPermissions')
+            ->with('role-1', ['perm-1', 'perm-2'])
+            ->willReturn(['success' => 2, 'failed' => 0, 'assignments' => []]);
+        $audit = $this->createMock(AuditService::class);
+        $audit->expects(self::once())
+            ->method('logSecurityEvent')
+            ->with('role.permissions.assigned', self::anything(), 'real-admin');
+
+        $response = $this->controller($roles, $rp, $audit)
+            ->assignPermissions(new RolePermissionsData(['perm-1', 'perm-2']), $this->request('role-1'));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_replace_permissions_syncs_full_set(): void
+    {
+        $roles = $this->createMock(RoleRepository::class);
+        $roles->method('findRecordByUuid')->willReturn(['uuid' => 'role-1']);
+        $rp = $this->createMock(RolePermissionRepository::class);
+        $rp->expects(self::once())
+            ->method('replaceRolePermissions')
+            ->with('role-1', ['perm-1'])
+            ->willReturn(true);
+        $rp->method('getRolePermissions')->willReturn([['permission_uuid' => 'perm-1']]);
+
+        $response = $this->controller($roles, $rp)
+            ->replacePermissions(new RolePermissionsData(['perm-1']), $this->request('role-1'));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_revoke_permission_removes_grant(): void
+    {
+        $roles = $this->createMock(RoleRepository::class);
+        $roles->method('findRecordByUuid')->willReturn(['uuid' => 'role-1']);
+        $rp = $this->createMock(RolePermissionRepository::class);
+        $rp->expects(self::once())
+            ->method('revokePermissionFromRole')
+            ->with('role-1', 'perm-1')
+            ->willReturn(true);
+
+        $response = $this->controller($roles, $rp)
+            ->revokePermission($this->request('role-1', [], 'perm-1'));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    private function controller(
+        RoleRepository $roles,
+        RolePermissionRepository $rp,
+        ?AuditService $audit = null,
+    ): RoleController {
+        return new RoleController(
+            $this->createMock(RoleService::class),
+            $roles,
+            $rp,
+            $audit ?? $this->createMock(AuditService::class),
+        );
+    }
+
+    /** @param array<string,mixed> $body */
+    private function request(string $roleUuid, array $body = [], string $permissionUuid = ''): Request
+    {
+        $request = Request::create('/x', 'POST', [], [], [], [], (string) json_encode($body));
+        $request->attributes->set('uuid', $roleUuid);
+        if ($permissionUuid !== '') {
+            $request->attributes->set('permission_uuid', $permissionUuid);
+        }
+        $request->attributes->set('auth.user', new UserIdentity('real-admin', ['administrator']));
+
+        return $request;
+    }
+}


### PR DESCRIPTION
## [1.9.0] - 2026-06-23

### Added
- **Role ↔ permission HTTP endpoints.** The `RolePermissionRepository` was already capable of
  granting/revoking a role's permissions, but it wasn't exposed over the API. Four new routes on
  `RoleController` close the gap:
  - `GET /rbac/roles/{uuid}/permissions` — list a role's permission grants (`roles.view`).
  - `POST /rbac/roles/{uuid}/permissions` — grant permissions additively; body `permission_uuids` (`roles.edit`).
  - `PUT /rbac/roles/{uuid}/permissions` — replace/sync the full set; body `permission_uuids`, empty clears all (`roles.edit`).
  - `DELETE /rbac/roles/{uuid}/permissions/{permission_uuid}` — revoke a single grant (`roles.edit`).

  Each validates the role exists; the mutating routes audit the change via `logSecurityEvent`.

### Changed
- **Request bodies are now typed `RequestData` DTOs.** Every body-accepting endpoint across
  `RoleController`, `PermissionController` and `UserRoleController` now declares a DTO parameter
  (in `src/Http/DTOs/`) instead of reading `$request->toArray()` with inline `empty()` checks. The
  router validates and hydrates the DTO before injection, so structural validation is declarative
  and the OpenAPI generator reflects a typed request-body schema (and a documented `422`) for each.
  Bonus hardening: actor/grantor fields (`assigned_by`, `granted_by`) are no longer DTO fields, so
  they can only come from the authenticated identity — body spoofing is structurally impossible.
