### PR TITLE
Standardize RBAC roles and update permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-06-23
+
+### Changed
+- **Default role model standardized.** `administrator` now grants full role management
+  (`roles.create`/`roles.edit`/`roles.delete`) on top of `roles.assign`, so a site admin can fully
+  run the roles/permissions surface; `system.config` stays superuser-only. The `user` role is now
+  **read-only** — it gets `content.view` only (previously also `content.create`/`content.edit`).
+
+### Removed
+- **The `manager` default role** (level 60). Apps that relied on it should assign `administrator`
+  or define their own role.
+
+> Seed changes apply to **fresh installs**; existing installs keep their already-seeded roles
+> (re-run the seed migration to adopt the new defaults).
+
 ## [1.9.0] - 2026-06-23
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",

--- a/migrations/003_SeedDefaultRoles.php
+++ b/migrations/003_SeedDefaultRoles.php
@@ -62,14 +62,6 @@ class SeedDefaultRoles implements MigrationInterface
                 'is_system' => true,
                 'status' => 'active'
             ],
-            'manager' => [
-                'name' => 'Manager',
-                'slug' => 'manager',
-                'description' => 'User manager with limited admin access',
-                'level' => 60,
-                'is_system' => true,
-                'status' => 'active'
-            ],
             'user' => [
                 'name' => 'User',
                 'slug' => 'user',
@@ -253,21 +245,16 @@ class SeedDefaultRoles implements MigrationInterface
                 'rol_edit', 'rol_delete', 'rol_assign', 'cnt_view',
                 'cnt_create', 'cnt_edit', 'cnt_delete'
             ],
-            // Administrator gets most permissions except system config
+            // Administrator gets full role/user/content management, but not system config
+            // (catalog-level changes stay superuser-only).
             'administrator' => [
-                'sys_access', 'usr_view', 'usr_create', 'usr_edit',
-                'usr_delete', 'rol_view', 'rol_assign', 'cnt_view',
-                'cnt_create', 'cnt_edit', 'cnt_delete'
+                'sys_access', 'usr_view', 'usr_create', 'usr_edit', 'usr_delete',
+                'rol_view', 'rol_create', 'rol_edit', 'rol_delete', 'rol_assign',
+                'cnt_view', 'cnt_create', 'cnt_edit', 'cnt_delete'
             ],
-            // Manager gets user and content management
-            'manager' => [
-                'sys_access', 'usr_view', 'usr_edit', 'rol_view',
-                'rol_assign', 'cnt_view', 'cnt_create', 'cnt_edit',
-                'cnt_delete'
-            ],
-            // User gets basic content access
+            // User is basic: read-only content access.
             'user' => [
-                'cnt_view', 'cnt_create', 'cnt_edit'
+                'cnt_view'
             ]
         ];
 


### PR DESCRIPTION
## [1.10.0] - 2026-06-23

### Changed
- **Default role model standardized.** `administrator` now grants full role management
  (`roles.create`/`roles.edit`/`roles.delete`) on top of `roles.assign`, so a site admin can fully
  run the roles/permissions surface; `system.config` stays superuser-only. The `user` role is now
  **read-only** — it gets `content.view` only (previously also `content.create`/`content.edit`).

### Removed
- **The `manager` default role** (level 60). Apps that relied on it should assign `administrator`
  or define their own role.

> Seed changes apply to **fresh installs**; existing installs keep their already-seeded roles
> (re-run the seed migration to adopt the new defaults).
