### PR TITLE
Fix RoleController DI: pass RolePermissionRepository (v1.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-06-23
+
+### Fixed
+- **`GET /rbac/roles/*` (and every `RoleController` route) no longer 500s.** The `RoleController`
+  service definition's `arguments` list was not updated when `RolePermissionRepository` was added as
+  constructor argument #3 in 1.9.0 — it still passed only `RoleService`, `RoleRepository`, `AuditService`,
+  so the container instantiated the controller with `AuditService` in the `$rolePermissions` slot and a
+  missing 4th argument, throwing `ArgumentCountError` ("Argument #3 ($rolePermissions)") on every role
+  route. The definition now passes `RolePermissionRepository` in position 3 and `AuditService` in
+  position 4, matching the constructor. (The existing controller test constructs `RoleController`
+  directly, so it did not exercise the container definition — hence the gap.)
+
 ## [1.10.0] - 2026-06-23
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.10.0",
+            "version": "1.10.1",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",

--- a/src/Services/AegisServiceProvider.php
+++ b/src/Services/AegisServiceProvider.php
@@ -117,6 +117,7 @@ class AegisServiceProvider extends ServiceProvider
                 'arguments' => [
                     '@' . RoleService::class,
                     '@' . RoleRepository::class,
+                    '@' . RolePermissionRepository::class,
                     '@' . AuditService::class,
                 ],
             ],


### PR DESCRIPTION
The RoleController service definition's arguments list was not updated when RolePermissionRepository was added as constructor arg #3 in 1.9.0, so the container built the controller with AuditService in the wrong slot and a missing 4th argument — every /rbac/roles/* route threw ArgumentCountError (500). The definition now passes RolePermissionRepository in position 3 and AuditService in position 4.