### PR TITLE
Fix RBAC routes, enable user permissions, and enrich user roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-06-24
+
+### Changed
+- **Assigning a permission directly to a user no longer requires `system.config`.** The user-side
+  assignment routes — `POST /rbac/permissions/{uuid}/assign`, `DELETE /rbac/permissions/{uuid}/revoke`,
+  `POST /rbac/permissions/batch-assign`, `POST /rbac/permissions/batch-revoke` — are now gated
+  `users.edit` (the user-side analog of `roles.edit`, which already gates editing a role's
+  permissions), so administrators can manage a user's direct permissions. **Defining** permissions
+  (`create`/`update`/`delete`) stays superuser-only (`system.config`).
+
+### Fixed
+- **`Permission` and `UserPermission` now implement `JsonSerializable`.** Like `RolePermission` in
+  1.10.2, their private properties encoded to `{}` — so `GET /rbac/users/{uuid}/permissions` (a user's
+  direct permissions) returned entries whose nested `permission` carried no slug/uuid. Both now
+  serialize via `toArray()`.
+
 ## [1.10.2] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.11.0] - 2026-06-24
+## [1.12.0] - 2026-06-24
+
+### Added
+- **Roles now appear on the identity store's user records.** A new `UserRoleEnricher` (tagged
+  `users.record_enricher`, the framework 1.62.0 seam) attaches each user's `roles` —
+  `[{uuid,name,slug}]` — to the records glueful/users returns on `/users`, `/users/{uuid}` and `/me`,
+  so an admin sees roles inline without a second request. It batch-loads via a new
+  `UserRoleRepository::getRolesForUsers()` (one JOIN for the whole page — no N+1; excludes
+  soft-deleted roles and expired assignments). glueful/users needs no dependency on Aegis. Requires
+  framework `^1.62.0`.
 
 ### Changed
 - **Assigning a permission directly to a user no longer requires `system.config`.** The user-side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.10.1] - 2026-06-23
+## [1.10.2] - 2026-06-24
+
+### Fixed
+- **Every single-resource RBAC route (`/{uuid}`, `/{user_uuid}`, …) no longer 404s.** The controllers
+  read the matched route id via `$request->attributes->get('uuid')`, but the framework router stores
+  matched params under the `_route_params` attribute (and injects them as handler arguments) — it does
+  not set a top-level `uuid` attribute. The id was therefore always empty, so role show/update/delete,
+  permission assign/replace/revoke, role-permission listing, and the user-role operations all returned
+  "not found". A new `ReadsRouteParams` trait reads from `_route_params`; all three controllers now use it.
+- **`GET /rbac/roles/{uuid}/permissions` now returns each grant's fields.** `RolePermission` had only
+  private properties and did not implement `JsonSerializable`, so it `json_encode`d to `{}` — the
+  response carried no `permission_uuid`. It now implements `JsonSerializable` (`jsonSerialize()` →
+  `toArray()`).
 
 ### Fixed
 - **`GET /rbac/roles/*` (and every `RoleController` route) no longer 500s.** The `RoleController`

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3"
     },
     "require-dev": {
-        "glueful/framework": "^1.60.0",
+        "glueful/framework": "^1.62.0",
         "phpunit/phpunit": "^10.0",
         "phpstan/phpstan": "^1.10"
     },
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",
@@ -46,7 +46,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider",
             "requires": {
-                "glueful": ">=1.60.0",
+                "glueful": ">=1.62.0",
                 "extensions": []
             }
         }

--- a/src/Controllers/PermissionController.php
+++ b/src/Controllers/PermissionController.php
@@ -9,6 +9,7 @@ use Glueful\Extensions\Aegis\Services\PermissionAssignmentService;
 use Glueful\Extensions\Aegis\Services\AuditService;
 use Glueful\Extensions\Aegis\Repositories\PermissionRepository;
 use Glueful\Extensions\Aegis\Repositories\UserPermissionRepository;
+use Glueful\Extensions\Aegis\Http\Concerns\ReadsRouteParams;
 use Glueful\Extensions\Aegis\Http\Concerns\ResolvesActor;
 use Glueful\Extensions\Aegis\Http\DTOs\AssignPermissionToUserData;
 use Glueful\Extensions\Aegis\Http\DTOs\BatchAssignPermissionsData;
@@ -34,6 +35,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class PermissionController
 {
+    use ReadsRouteParams;
     use ResolvesActor;
 
     private PermissionAssignmentService $permissionService;
@@ -116,7 +118,7 @@ class PermissionController
     public function show(Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
 
             $permission = $this->permissionRepository->findRecordByUuid($uuid);
             if (!$permission) {
@@ -183,7 +185,7 @@ class PermissionController
     public function update(UpdatePermissionData $input, Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
             $data = $input->toArray();
 
             $oldPermission = $this->permissionRepository->findRecordByUuid($uuid);
@@ -225,7 +227,7 @@ class PermissionController
     public function delete(Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
             $force = filter_var($request->query->get('force', false), FILTER_VALIDATE_BOOLEAN);
 
             $permission = $this->permissionRepository->findRecordByUuid($uuid);
@@ -261,7 +263,7 @@ class PermissionController
     public function assignToUser(AssignPermissionToUserData $input, Request $request): Response
     {
         try {
-            $permissionUuid = $request->attributes->get('uuid', '');
+            $permissionUuid = $this->routeParam($request, 'uuid');
 
             $permission = $this->permissionRepository->findRecordByUuid($permissionUuid);
             if (!$permission) {
@@ -320,7 +322,7 @@ class PermissionController
     public function revokeFromUser(RevokePermissionFromUserData $input, Request $request): Response
     {
         try {
-            $permissionUuid = $request->attributes->get('uuid', '');
+            $permissionUuid = $this->routeParam($request, 'uuid');
 
             $permission = $this->permissionRepository->findRecordByUuid($permissionUuid);
             if (!$permission) {
@@ -474,7 +476,7 @@ class PermissionController
     public function getUserDirectPermissions(Request $request): Response
     {
         try {
-            $userUuid = $request->attributes->get('user_uuid', '');
+            $userUuid = $this->routeParam($request, 'user_uuid');
             $activeOnly = filter_var($request->query->get('active_only', true), FILTER_VALIDATE_BOOLEAN);
 
             $filters = [];
@@ -505,7 +507,7 @@ class PermissionController
     public function getUserEffectivePermissions(Request $request): Response
     {
         try {
-            $userUuid = $request->attributes->get('user_uuid', '');
+            $userUuid = $this->routeParam($request, 'user_uuid');
             $scope = $request->query->get('scope', '');
             if (is_string($scope) && !empty($scope)) {
                 $scope = json_decode($scope, true) ?? [];

--- a/src/Controllers/RoleController.php
+++ b/src/Controllers/RoleController.php
@@ -9,6 +9,7 @@ use Glueful\Extensions\Aegis\Services\RoleService;
 use Glueful\Extensions\Aegis\Services\AuditService;
 use Glueful\Extensions\Aegis\Repositories\RoleRepository;
 use Glueful\Extensions\Aegis\Repositories\RolePermissionRepository;
+use Glueful\Extensions\Aegis\Http\Concerns\ReadsRouteParams;
 use Glueful\Extensions\Aegis\Http\Concerns\ResolvesActor;
 use Glueful\Extensions\Aegis\Http\DTOs\AssignRoleToUserData;
 use Glueful\Extensions\Aegis\Http\DTOs\CreateRoleData;
@@ -33,6 +34,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class RoleController
 {
+    use ReadsRouteParams;
     use ResolvesActor;
 
     private RoleService $roleService;
@@ -123,7 +125,7 @@ class RoleController
     public function show(Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
 
             $role = $this->roleRepository->findRecordByUuid($uuid);
             if (!$role) {
@@ -192,7 +194,7 @@ class RoleController
     public function update(UpdateRoleData $input, Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
             $data = $input->toArray();
 
             $oldRole = $this->roleRepository->findRecordByUuid($uuid);
@@ -235,7 +237,7 @@ class RoleController
     public function delete(Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
             $force = filter_var($request->query->get('force', false), FILTER_VALIDATE_BOOLEAN);
 
             $role = $this->roleRepository->findRecordByUuid($uuid);
@@ -271,7 +273,7 @@ class RoleController
     public function assignToUser(AssignRoleToUserData $input, Request $request): Response
     {
         try {
-            $roleUuid = $request->attributes->get('uuid', '');
+            $roleUuid = $this->routeParam($request, 'uuid');
 
             $actor = $this->actorUuid($request);
             $options = [
@@ -311,7 +313,7 @@ class RoleController
     public function revokeFromUser(RevokeRoleFromUserData $input, Request $request): Response
     {
         try {
-            $roleUuid = $request->attributes->get('uuid', '');
+            $roleUuid = $this->routeParam($request, 'uuid');
 
             $revoked = $this->roleService->revokeRoleFromUser($input->user_uuid, $roleUuid);
             if (!$revoked) {
@@ -343,7 +345,7 @@ class RoleController
     public function getUsers(Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
             $page = (int) $request->query->get('page', 1);
             $perPage = (int) $request->query->get('per_page', 25);
 
@@ -379,7 +381,7 @@ class RoleController
     public function getPermissions(Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
             if (!$this->roleRepository->findRecordByUuid($uuid)) {
                 return Response::notFound('Role not found.');
             }
@@ -411,7 +413,7 @@ class RoleController
     public function assignPermissions(RolePermissionsData $input, Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
 
             if ($input->permission_uuids === []) {
                 return Response::validation(
@@ -456,7 +458,7 @@ class RoleController
     public function replacePermissions(RolePermissionsData $input, Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
 
             if (!$this->roleRepository->findRecordByUuid($uuid)) {
                 return Response::notFound('Role not found.');
@@ -498,8 +500,8 @@ class RoleController
     public function revokePermission(Request $request): Response
     {
         try {
-            $uuid = $request->attributes->get('uuid', '');
-            $permissionUuid = $request->attributes->get('permission_uuid', '');
+            $uuid = $this->routeParam($request, 'uuid');
+            $permissionUuid = $this->routeParam($request, 'permission_uuid');
 
             if (!$this->roleRepository->findRecordByUuid($uuid)) {
                 return Response::notFound('Role not found.');

--- a/src/Controllers/UserRoleController.php
+++ b/src/Controllers/UserRoleController.php
@@ -9,6 +9,7 @@ use Glueful\Extensions\Aegis\Services\RoleService;
 use Glueful\Extensions\Aegis\Services\PermissionAssignmentService;
 use Glueful\Extensions\Aegis\Services\AuditService;
 use Glueful\Extensions\Aegis\Repositories\UserRoleRepository;
+use Glueful\Extensions\Aegis\Http\Concerns\ReadsRouteParams;
 use Glueful\Extensions\Aegis\Http\Concerns\ResolvesActor;
 use Glueful\Extensions\Aegis\Http\DTOs\BulkRoleUsersData;
 use Glueful\Extensions\Aegis\Http\DTOs\CheckUserRoleData;
@@ -29,6 +30,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class UserRoleController
 {
+    use ReadsRouteParams;
     use ResolvesActor;
 
     private RoleService $roleService;
@@ -64,7 +66,7 @@ class UserRoleController
     public function getUserRoles(Request $request): Response
     {
         try {
-            $userUuid = $request->attributes->get('user_uuid', '');
+            $userUuid = $this->routeParam($request, 'user_uuid');
             $scope = $request->query->get('scope', '');
             if (is_string($scope) && !empty($scope)) {
                 $scope = json_decode($scope, true) ?? [];
@@ -95,7 +97,7 @@ class UserRoleController
     public function assignRoles(UserRolesData $input, Request $request): Response
     {
         try {
-            $userUuid = $request->attributes->get('user_uuid', '');
+            $userUuid = $this->routeParam($request, 'user_uuid');
 
             if ($input->role_uuids === []) {
                 return Response::validation(
@@ -156,8 +158,8 @@ class UserRoleController
     public function revokeRole(Request $request): Response
     {
         try {
-            $userUuid = $request->attributes->get('user_uuid', '');
-            $roleUuid = $request->attributes->get('role_uuid', '');
+            $userUuid = $this->routeParam($request, 'user_uuid');
+            $roleUuid = $this->routeParam($request, 'role_uuid');
 
             $revoked = $this->roleService->revokeRoleFromUser($userUuid, $roleUuid);
             if (!$revoked) {
@@ -187,7 +189,7 @@ class UserRoleController
     public function replaceUserRoles(UserRolesData $input, Request $request): Response
     {
         try {
-            $userUuid = $request->attributes->get('user_uuid', '');
+            $userUuid = $this->routeParam($request, 'user_uuid');
 
             $scope = $input->scope;
             $currentRoles = $this->roleService->getUserRoles($userUuid, $scope);
@@ -256,7 +258,7 @@ class UserRoleController
     public function checkUserRole(CheckUserRoleData $input, Request $request): Response
     {
         try {
-            $userUuid = $request->attributes->get('user_uuid', '');
+            $userUuid = $this->routeParam($request, 'user_uuid');
 
             $scope = $input->scope;
             $hasRole = $this->roleService->userHasRole($userUuid, $input->role_slug, $scope);
@@ -287,7 +289,7 @@ class UserRoleController
     public function getUserAccessOverview(Request $request): Response
     {
         try {
-            $userUuid = $request->attributes->get('user_uuid', '');
+            $userUuid = $this->routeParam($request, 'user_uuid');
             $scope = $request->query->get('scope', '');
             if (is_string($scope) && !empty($scope)) {
                 $scope = json_decode($scope, true) ?? [];
@@ -328,7 +330,7 @@ class UserRoleController
     public function getUserRoleHistory(Request $request): Response
     {
         try {
-            $userUuid = $request->attributes->get('user_uuid', '');
+            $userUuid = $this->routeParam($request, 'user_uuid');
             $page = (int) $request->query->get('page', 1);
             $perPage = (int) $request->query->get('per_page', 25);
             $includeDeleted = filter_var($request->query->get('include_deleted', true), FILTER_VALIDATE_BOOLEAN);
@@ -365,7 +367,7 @@ class UserRoleController
     public function bulkAssignRoleToUsers(BulkRoleUsersData $input, Request $request): Response
     {
         try {
-            $roleUuid = $request->attributes->get('role_uuid', '');
+            $roleUuid = $this->routeParam($request, 'role_uuid');
 
             if ($input->user_uuids === []) {
                 return Response::validation(
@@ -428,7 +430,7 @@ class UserRoleController
     public function bulkRevokeRoleFromUsers(BulkRoleUsersData $input, Request $request): Response
     {
         try {
-            $roleUuid = $request->attributes->get('role_uuid', '');
+            $roleUuid = $this->routeParam($request, 'role_uuid');
 
             if ($input->user_uuids === []) {
                 return Response::validation(

--- a/src/Http/Concerns/ReadsRouteParams.php
+++ b/src/Http/Concerns/ReadsRouteParams.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Http\Concerns;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Reads matched route parameters from a request.
+ *
+ * The framework router stores matched params under the `_route_params` attribute (and injects them
+ * as handler method arguments by name). It does NOT expose each param as its own top-level request
+ * attribute, so `$request->attributes->get('uuid')` is always empty and every `/{uuid}` route would
+ * 404 ("not found"). This helper pulls from the place the router actually populates.
+ */
+trait ReadsRouteParams
+{
+    protected function routeParam(Request $request, string $name, string $default = ''): string
+    {
+        $params = $request->attributes->get('_route_params');
+        if (is_array($params) && isset($params[$name]) && is_scalar($params[$name])) {
+            return (string) $params[$name];
+        }
+        return $default;
+    }
+}

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -13,7 +13,7 @@ namespace Glueful\Extensions\Aegis\Models;
  * - System permission protection
  * - Metadata support for flexible permissions
  */
-class Permission
+class Permission implements \JsonSerializable
 {
     private string $uuid;
     private string $name;
@@ -185,6 +185,18 @@ class Permission
             'metadata' => json_encode($this->metadata),
             'created_at' => $this->createdAt
         ];
+    }
+
+    /**
+     * Serialize for JSON responses. Without this, the model's private properties encode to an empty
+     * object (`{}`), so endpoints returning Permission objects (e.g. a user's direct permissions)
+     * would carry no slug/uuid for clients to read.
+     *
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 
     /**

--- a/src/Models/RolePermission.php
+++ b/src/Models/RolePermission.php
@@ -10,7 +10,7 @@ namespace Glueful\Extensions\Aegis\Models;
  * Represents a permission assignment to a role in the RBAC system.
  * Manages the many-to-many relationship between roles and permissions.
  */
-class RolePermission
+class RolePermission implements \JsonSerializable
 {
     private int $id;
     private string $uuid;
@@ -246,6 +246,18 @@ class RolePermission
             'is_expired' => $this->isExpired(),
             'is_active' => $this->isActive()
         ];
+    }
+
+    /**
+     * Serialize for JSON responses. Without this, the model's private properties would encode to an
+     * empty object (`{}`), so a `GET /rbac/roles/{uuid}/permissions` response would carry no
+     * `permission_uuid` for clients to read.
+     *
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 
     /**

--- a/src/Models/UserPermission.php
+++ b/src/Models/UserPermission.php
@@ -14,7 +14,7 @@ namespace Glueful\Extensions\Aegis\Models;
  * - Permission overrides (grant or deny)
  * - Assignment tracking and audit trail
  */
-class UserPermission
+class UserPermission implements \JsonSerializable
 {
     private string $uuid;
     private string $userUuid;
@@ -261,6 +261,16 @@ class UserPermission
             'expires_at' => $this->expiresAt,
             'created_at' => $this->createdAt
         ];
+    }
+
+    /**
+     * Serialize for JSON responses (private props would otherwise encode to `{}`).
+     *
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 
     /**

--- a/src/Repositories/UserRoleRepository.php
+++ b/src/Repositories/UserRoleRepository.php
@@ -133,6 +133,45 @@ class UserRoleRepository extends BaseRepository
     }
 
     /**
+     * Batch-load each user's active role {uuid,name,slug} list in ONE query (no N+1). Excludes
+     * soft-deleted roles and expired assignments. Keyed by user_uuid; users with no roles are absent.
+     *
+     * @param list<string> $userUuids
+     * @return array<string, list<array{uuid: string, name: string, slug: string}>>
+     */
+    public function getRolesForUsers(array $userUuids): array
+    {
+        $out = [];
+        if ($userUuids === []) {
+            return $out;
+        }
+        $now = $this->db->getDriver()->formatDateTime();
+        $rows = $this->db->table('user_roles')
+            ->select([
+                'user_roles.user_uuid AS user_uuid',
+                'roles.uuid AS role_uuid',
+                'roles.name AS role_name',
+                'roles.slug AS role_slug',
+            ])
+            ->join('roles', 'roles.uuid', '=', 'user_roles.role_uuid')
+            ->whereIn('user_roles.user_uuid', $userUuids)
+            ->whereNull('roles.deleted_at')
+            ->where(function ($q) use ($now) {
+                $q->where('user_roles.expires_at', '>=', $now)
+                  ->orWhereNull('user_roles.expires_at');
+            })
+            ->get();
+        foreach ($rows as $r) {
+            $out[(string) $r['user_uuid']][] = [
+                'uuid' => (string) $r['role_uuid'],
+                'name' => (string) $r['role_name'],
+                'slug' => (string) $r['role_slug'],
+            ];
+        }
+        return $out;
+    }
+
+    /**
      * @return list<UserRole>
      */
     public function findByRole(string $roleUuid): array

--- a/src/Services/AegisServiceProvider.php
+++ b/src/Services/AegisServiceProvider.php
@@ -9,6 +9,7 @@ use Glueful\Database\Migrations\MigrationPriority;
 use Glueful\Extensions\ServiceProvider;
 use Glueful\Extensions\Aegis\AegisPermissionProvider;
 use Glueful\Extensions\Aegis\IdentityClaimsProvider;
+use Glueful\Extensions\Aegis\UserRoleEnricher;
 use Glueful\Extensions\Aegis\Repositories\RoleRepository;
 use Glueful\Extensions\Aegis\Repositories\PermissionRepository;
 use Glueful\Extensions\Aegis\Repositories\UserRoleRepository;
@@ -98,6 +99,16 @@ class AegisServiceProvider extends ServiceProvider
                 'shared' => true,
                 'arguments' => ['@' . UserRoleRepository::class],
                 'tags' => ['identity.claims_provider'],
+            ],
+
+            // Attaches each user's roles to user RECORDS the identity store returns (the /users list,
+            // /users/{uuid}, /me). Tagged 'users.record_enricher' so glueful/users collects it without
+            // depending on Aegis — the read-side symmetric of the claims provider above.
+            UserRoleEnricher::class => [
+                'class' => UserRoleEnricher::class,
+                'shared' => true,
+                'arguments' => ['@' . UserRoleRepository::class],
+                'tags' => ['users.record_enricher'],
             ],
 
             // Controllers

--- a/src/UserRoleEnricher.php
+++ b/src/UserRoleEnricher.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis;
+
+use Glueful\Auth\Contracts\UserRecordEnricherInterface;
+use Glueful\Extensions\Aegis\Repositories\UserRoleRepository;
+
+/**
+ * Attaches each user's `roles` to user records the identity store is about to return.
+ *
+ * Registered under the core `users.record_enricher` tag (see {@see UserRecordEnricherInterface}),
+ * so glueful/users surfaces roles on its `/users`, `/users/{uuid}` and `/me` payloads without ever
+ * depending on Aegis. Symmetric to {@see IdentityClaimsProvider}, which folds roles into the
+ * authenticated identity at login — this folds them into arbitrary read batches. One batched query.
+ */
+final class UserRoleEnricher implements UserRecordEnricherInterface
+{
+    public function __construct(private UserRoleRepository $userRoles)
+    {
+    }
+
+    /**
+     * @param list<string> $userUuids
+     * @return array<string, array<string, mixed>>
+     */
+    public function enrich(array $userUuids): array
+    {
+        $out = [];
+        foreach ($this->userRoles->getRolesForUsers($userUuids) as $userUuid => $roles) {
+            $out[$userUuid] = ['roles' => $roles];
+        }
+        return $out;
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -63,10 +63,13 @@ $router->group(['prefix' => '/rbac', 'middleware' => ['auth']], function(Router 
         $router->post('/', [PermissionController::class, 'create'])->middleware('aegis_permission:system.config');
         $router->put('/{uuid}', [PermissionController::class, 'update'])->middleware('aegis_permission:system.config');
         $router->delete('/{uuid}', [PermissionController::class, 'delete'])->middleware('aegis_permission:system.config');
-        $router->post('/{uuid}/assign', [PermissionController::class, 'assignToUser'])->middleware('aegis_permission:system.config');
-        $router->delete('/{uuid}/revoke', [PermissionController::class, 'revokeFromUser'])->middleware('aegis_permission:system.config');
-        $router->post('/batch-assign', [PermissionController::class, 'batchAssign'])->middleware('aegis_permission:system.config');
-        $router->post('/batch-revoke', [PermissionController::class, 'batchRevoke'])->middleware('aegis_permission:system.config');
+        // Assigning permissions DIRECTLY to a user is the user-side analog of editing a role's
+        // permissions (gated roles.edit), so it is gated `users.edit` — administrators hold it.
+        // Defining permissions (create/update/delete above) stays superuser-only (system.config).
+        $router->post('/{uuid}/assign', [PermissionController::class, 'assignToUser'])->middleware('aegis_permission:users.edit');
+        $router->delete('/{uuid}/revoke', [PermissionController::class, 'revokeFromUser'])->middleware('aegis_permission:users.edit');
+        $router->post('/batch-assign', [PermissionController::class, 'batchAssign'])->middleware('aegis_permission:users.edit');
+        $router->post('/batch-revoke', [PermissionController::class, 'batchRevoke'])->middleware('aegis_permission:users.edit');
     });
 
     // User-specific RBAC Routes

--- a/tests/Unit/AuditActorAttributionTest.php
+++ b/tests/Unit/AuditActorAttributionTest.php
@@ -55,7 +55,7 @@ final class AuditActorAttributionTest extends TestCase
 
         // The DTO has no `assigned_by` field, so the actor can only come from auth.user.
         $request = Request::create('/x', 'POST');
-        $request->attributes->set('uuid', 'role-1');
+        $request->attributes->set('_route_params', ['uuid' => 'role-1']);
         $request->attributes->set('auth.user', new UserIdentity('real-admin', ['administrator']));
 
         $response = $controller->assignToUser(new AssignRoleToUserData(user_uuid: 'target-user'), $request);

--- a/tests/Unit/RolePermissionEndpointsTest.php
+++ b/tests/Unit/RolePermissionEndpointsTest.php
@@ -130,10 +130,12 @@ final class RolePermissionEndpointsTest extends TestCase
     private function request(string $roleUuid, array $body = [], string $permissionUuid = ''): Request
     {
         $request = Request::create('/x', 'POST', [], [], [], [], (string) json_encode($body));
-        $request->attributes->set('uuid', $roleUuid);
+        // The framework router exposes matched params under `_route_params` (read via routeParam()).
+        $params = ['uuid' => $roleUuid];
         if ($permissionUuid !== '') {
-            $request->attributes->set('permission_uuid', $permissionUuid);
+            $params['permission_uuid'] = $permissionUuid;
         }
+        $request->attributes->set('_route_params', $params);
         $request->attributes->set('auth.user', new UserIdentity('real-admin', ['administrator']));
 
         return $request;


### PR DESCRIPTION
## [1.12.0] - 2026-06-24

### Added
- **Roles now appear on the identity store's user records.** A new `UserRoleEnricher` (tagged
  `users.record_enricher`, the framework 1.62.0 seam) attaches each user's `roles` —
  `[{uuid,name,slug}]` — to the records glueful/users returns on `/users`, `/users/{uuid}` and `/me`,
  so an admin sees roles inline without a second request. It batch-loads via a new
  `UserRoleRepository::getRolesForUsers()` (one JOIN for the whole page — no N+1; excludes
  soft-deleted roles and expired assignments). glueful/users needs no dependency on Aegis. Requires
  framework `^1.62.0`.

### Changed
- **Assigning a permission directly to a user no longer requires `system.config`.** The user-side
  assignment routes — `POST /rbac/permissions/{uuid}/assign`, `DELETE /rbac/permissions/{uuid}/revoke`,
  `POST /rbac/permissions/batch-assign`, `POST /rbac/permissions/batch-revoke` — are now gated
  `users.edit` (the user-side analog of `roles.edit`, which already gates editing a role's
  permissions), so administrators can manage a user's direct permissions. **Defining** permissions
  (`create`/`update`/`delete`) stays superuser-only (`system.config`).

### Fixed
- **`Permission` and `UserPermission` now implement `JsonSerializable`.** Like `RolePermission` in
  1.10.2, their private properties encoded to `{}` — so `GET /rbac/users/{uuid}/permissions` (a user's
  direct permissions) returned entries whose nested `permission` carried no slug/uuid. Both now
  serialize via `toArray()`.