### PR TITLE
Add RBAC domain events for audit integration (v1.13.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 # --- OS / Misc ---
 .DS_Store
 *.log
+
+/storage/
+:memory:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-06-25
+
+### Added
+- **RBAC domain events for audit / notification / cache integration.** Six PSR-14 events under
+  `Glueful\Extensions\Aegis\Events\` are now dispatched from the pivot repositories on real mutations:
+  `RoleAssignedEvent` / `RoleRevokedEvent` (user↔role), `PermissionAssignedEvent` /
+  `PermissionRevokedEvent` (direct user↔permission grant), and `RolePermissionAssignedEvent` /
+  `RolePermissionRevokedEvent` (role↔permission). They fire from the single repository chokepoint every
+  entry point converges on (`UserRoleRepository::assignRole/revokeRole/revokeAllUserRoles`,
+  `UserPermissionRepository::create/revokeUserPermission/revokeAllUserPermissions`,
+  `RolePermissionRepository::assignPermissionToRole/revokePermissionFromRole/batch*`) — **exactly once**
+  per semantic action, one per affected item for batch/replace, and **nothing on a no-op** (re-assigning
+  an existing grant, revoking an absent one). This lets an extension (e.g. glueful/audit) record
+  *semantic* RBAC actions ("assigned Admin to Jane") rather than raw pivot-table writes, with no coupling
+  back to Aegis. Requires framework `^1.63.0` (the new `protected BaseRepository::dispatchEvent()`).
+
+### Fixed
+- **Pivot repositories now receive `ApplicationContext`, so the domain events (and the framework's entity
+  events) actually dispatch.** The provider's lazy getters, `BootstrapAdminCommand`, and — critically —
+  the `AegisServiceProvider` DI definitions all built `UserRoleRepository` / `UserPermissionRepository` /
+  `RolePermissionRepository` with a null context, which `BaseRepository::dispatchEvent()` silently no-ops
+  on. Every repo is now constructed with context (DI `arguments`, provider getters, command), so events
+  fire from every entry point (controller, provider, service, batch, bootstrap).
+- **`RolePermissionRepository::replaceRolePermissions()` now emits revoke events for removed links.** It
+  removed existing grants with a raw `delete()` loop that bypassed the semantic `revokePermissionFromRole`,
+  so a role-permission *replace/sync* dropped links without a `RolePermissionRevokedEvent`. Removals now
+  route through the semantic method.
+
 ## [1.12.0] - 2026-06-24
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3"
     },
     "require-dev": {
-        "glueful/framework": "^1.62.0",
+        "glueful/framework": "^1.63.0",
         "phpunit/phpunit": "^10.0",
         "phpstan/phpstan": "^1.10"
     },
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.12.0",
+            "version": "1.13.0",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",
@@ -46,7 +46,7 @@
             "publisher": "glueful-team",
             "provider": "Glueful\\Extensions\\Aegis\\Services\\AegisServiceProvider",
             "requires": {
-                "glueful": ">=1.62.0",
+                "glueful": ">=1.63.0",
                 "extensions": []
             }
         }

--- a/src/AegisPermissionProvider.php
+++ b/src/AegisPermissionProvider.php
@@ -103,7 +103,7 @@ public function initialize(array $config = []): void
     private function getRoleRepository(): RoleRepository
     {
         if ($this->roleRepository === null) {
-            $this->roleRepository = new RoleRepository();
+            $this->roleRepository = new RoleRepository(null, $this->context);
         }
         return $this->roleRepository;
     }
@@ -114,7 +114,7 @@ public function initialize(array $config = []): void
     private function getPermissionRepository(): PermissionRepository
     {
         if ($this->permissionRepository === null) {
-            $this->permissionRepository = new PermissionRepository();
+            $this->permissionRepository = new PermissionRepository(null, $this->context);
         }
         return $this->permissionRepository;
     }
@@ -125,7 +125,7 @@ public function initialize(array $config = []): void
     private function getUserRoleRepository(): UserRoleRepository
     {
         if ($this->userRoleRepository === null) {
-            $this->userRoleRepository = new UserRoleRepository();
+            $this->userRoleRepository = new UserRoleRepository(null, $this->context);
         }
         return $this->userRoleRepository;
     }
@@ -136,7 +136,7 @@ public function initialize(array $config = []): void
     private function getUserPermissionRepository(): UserPermissionRepository
     {
         if ($this->userPermissionRepository === null) {
-            $this->userPermissionRepository = new UserPermissionRepository();
+            $this->userPermissionRepository = new UserPermissionRepository(null, $this->context);
         }
         return $this->userPermissionRepository;
     }
@@ -147,7 +147,7 @@ public function initialize(array $config = []): void
     private function getRolePermissionRepository(): RolePermissionRepository
     {
         if ($this->rolePermissionRepository === null) {
-            $this->rolePermissionRepository = new RolePermissionRepository();
+            $this->rolePermissionRepository = new RolePermissionRepository(null, $this->context);
         }
         return $this->rolePermissionRepository;
     }

--- a/src/Console/BootstrapAdminCommand.php
+++ b/src/Console/BootstrapAdminCommand.php
@@ -74,11 +74,14 @@ final class BootstrapAdminCommand extends BaseCommand
         );
 
         // 2) Bootstrap: resolve user, create/reuse role, additively grant, assign role.
+        //    Pass the application context into each repository so BaseRepository::dispatchEvent()
+        //    fires (it no-ops with a null context) when these repos emit RBAC domain events.
+        $context = $this->getContext();
         $service = new BootstrapAdminService(
             $this->getService(UserProviderInterface::class),
-            new RoleRepository(),
-            new PermissionRepository(),
-            new RolePermissionRepository(),
+            new RoleRepository(null, $context),
+            new PermissionRepository(null, $context),
+            new RolePermissionRepository(null, $context),
             $provider,
         );
 

--- a/src/Events/PermissionAssignedEvent.php
+++ b/src/Events/PermissionAssignedEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Events;
+
+use Glueful\Events\Contracts\BaseEvent;
+
+/**
+ * A direct permission was granted to a user (a user_permissions row was created).
+ *
+ * Aegis stores scope as a JSON `resource_filter` column — there is no `resource`
+ * positional. The decoded resource_filter (plus granted_by / expires_at) travels
+ * in $options.
+ */
+final class PermissionAssignedEvent extends BaseEvent
+{
+    /** @param array<string,mixed> $options resource_filter, granted_by, expires_at, … */
+    public function __construct(
+        public readonly string $userUuid,
+        public readonly string $permissionUuid,
+        public readonly array $options = [],
+    ) {
+        parent::__construct();
+    }
+}

--- a/src/Events/PermissionRevokedEvent.php
+++ b/src/Events/PermissionRevokedEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Events;
+
+use Glueful\Events\Contracts\BaseEvent;
+
+/** A direct permission was revoked from a user (a user_permissions row was deleted). */
+final class PermissionRevokedEvent extends BaseEvent
+{
+    public function __construct(
+        public readonly string $userUuid,
+        public readonly string $permissionUuid,
+    ) {
+        parent::__construct();
+    }
+}

--- a/src/Events/RoleAssignedEvent.php
+++ b/src/Events/RoleAssignedEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Events;
+
+use Glueful\Events\Contracts\BaseEvent;
+
+/** A role was assigned to a user (the user_roles pivot row was created). */
+final class RoleAssignedEvent extends BaseEvent
+{
+    /** @param array<string,mixed> $options granted_by, expires_at, scope, … */
+    public function __construct(
+        public readonly string $userUuid,
+        public readonly string $roleUuid,
+        public readonly array $options = [],
+    ) {
+        parent::__construct();
+    }
+}

--- a/src/Events/RolePermissionAssignedEvent.php
+++ b/src/Events/RolePermissionAssignedEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Events;
+
+use Glueful\Events\Contracts\BaseEvent;
+
+/** A permission was attached to a role (a role_permissions pivot row was created). */
+final class RolePermissionAssignedEvent extends BaseEvent
+{
+    /** @param array<string,mixed> $options resource_filter, constraints, granted_by, expires_at, … */
+    public function __construct(
+        public readonly string $roleUuid,
+        public readonly string $permissionUuid,
+        public readonly array $options = [],
+    ) {
+        parent::__construct();
+    }
+}

--- a/src/Events/RolePermissionRevokedEvent.php
+++ b/src/Events/RolePermissionRevokedEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Events;
+
+use Glueful\Events\Contracts\BaseEvent;
+
+/** A permission was detached from a role (a role_permissions pivot row was deleted). */
+final class RolePermissionRevokedEvent extends BaseEvent
+{
+    public function __construct(
+        public readonly string $roleUuid,
+        public readonly string $permissionUuid,
+    ) {
+        parent::__construct();
+    }
+}

--- a/src/Events/RoleRevokedEvent.php
+++ b/src/Events/RoleRevokedEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Events;
+
+use Glueful\Events\Contracts\BaseEvent;
+
+/** A role was revoked from a user (the user_roles pivot row was deleted). */
+final class RoleRevokedEvent extends BaseEvent
+{
+    public function __construct(
+        public readonly string $userUuid,
+        public readonly string $roleUuid,
+    ) {
+        parent::__construct();
+    }
+}

--- a/src/Repositories/RolePermissionRepository.php
+++ b/src/Repositories/RolePermissionRepository.php
@@ -6,6 +6,8 @@ namespace Glueful\Extensions\Aegis\Repositories;
 
 use Glueful\Repository\BaseRepository;
 use Glueful\Extensions\Aegis\Models\RolePermission;
+use Glueful\Extensions\Aegis\Events\RolePermissionAssignedEvent;
+use Glueful\Extensions\Aegis\Events\RolePermissionRevokedEvent;
 use Glueful\Helpers\Utils;
 
 /**
@@ -82,6 +84,8 @@ class RolePermissionRepository extends BaseRepository
             return null;
         }
 
+        $this->dispatchEvent(new RolePermissionAssignedEvent($roleUuid, $permissionUuid, $options));
+
         // Retrieve the full record
         $createdRecord = $this->find($createdUuid);
         return $createdRecord ? new RolePermission($createdRecord) : null;
@@ -106,7 +110,9 @@ class RolePermissionRepository extends BaseRepository
         }
 
         foreach ($assignments as $assignment) {
-            $this->delete($assignment['uuid']);
+            if ($this->delete($assignment['uuid'])) {
+                $this->dispatchEvent(new RolePermissionRevokedEvent($roleUuid, $permissionUuid));
+            }
         }
 
         return true;
@@ -263,10 +269,11 @@ class RolePermissionRepository extends BaseRepository
      */
     public function replaceRolePermissions(string $roleUuid, array $permissionUuids, array $options = []): bool
     {
-        // Remove all existing permissions
+        // Remove all existing permissions via the semantic method so each removed
+        // link emits a RolePermissionRevokedEvent (a raw delete() loop bypasses it).
         $existing = $this->getRolePermissions($roleUuid);
         foreach ($existing as $assignment) {
-            $this->delete($assignment->getUuid());
+            $this->revokePermissionFromRole($roleUuid, $assignment->getPermissionUuid());
         }
 
         // Assign new permissions

--- a/src/Repositories/UserPermissionRepository.php
+++ b/src/Repositories/UserPermissionRepository.php
@@ -4,6 +4,8 @@ namespace Glueful\Extensions\Aegis\Repositories;
 
 use Glueful\Repository\BaseRepository;
 use Glueful\Extensions\Aegis\Models\UserPermission;
+use Glueful\Extensions\Aegis\Events\PermissionAssignedEvent;
+use Glueful\Extensions\Aegis\Events\PermissionRevokedEvent;
 use Glueful\Helpers\Utils;
 
 /**
@@ -67,6 +69,24 @@ class UserPermissionRepository extends BaseRepository
         if (!$success) {
             throw new \RuntimeException('Failed to create user permission');
         }
+
+        // Grant chokepoint: decode the JSON resource_filter (there is NO `resource` key)
+        // and emit the semantic grant event.
+        $rf = isset($data['resource_filter']) && is_string($data['resource_filter'])
+            ? json_decode($data['resource_filter'], true)
+            : null;
+        $this->dispatchEvent(new PermissionAssignedEvent(
+            (string) ($data['user_uuid'] ?? ''),
+            (string) ($data['permission_uuid'] ?? ''),
+            array_filter(
+                [
+                    'resource_filter' => $rf,
+                    'granted_by' => $data['granted_by'] ?? null,
+                    'expires_at' => $data['expires_at'] ?? null,
+                ],
+                static fn($v) => $v !== null
+            ),
+        ));
 
         return $data['uuid'];
     }
@@ -245,15 +265,38 @@ class UserPermissionRepository extends BaseRepository
 
     public function revokeUserPermission(string $userUuid, string $permissionUuid): bool
     {
-        return (bool) $this->db->table($this->table)->where([
+        $deleted = (bool) $this->db->table($this->table)->where([
             'user_uuid' => $userUuid,
             'permission_uuid' => $permissionUuid
         ])->delete();
+
+        if ($deleted) {
+            $this->dispatchEvent(new PermissionRevokedEvent($userUuid, $permissionUuid));
+        }
+
+        return $deleted;
     }
 
     public function revokeAllUserPermissions(string $userUuid): bool
     {
-        return (bool) $this->db->table($this->table)->where(['user_uuid' => $userUuid])->delete();
+        // Read the permission_uuids first so we can emit one semantic event per removed grant.
+        $permissionUuids = array_column(
+            $this->db->table($this->table)
+                ->select(['permission_uuid'])
+                ->where(['user_uuid' => $userUuid])
+                ->get(),
+            'permission_uuid'
+        );
+
+        $deleted = (bool) $this->db->table($this->table)->where(['user_uuid' => $userUuid])->delete();
+
+        if ($deleted) {
+            foreach (array_unique($permissionUuids) as $permissionUuid) {
+                $this->dispatchEvent(new PermissionRevokedEvent($userUuid, (string) $permissionUuid));
+            }
+        }
+
+        return $deleted;
     }
 
     /**

--- a/src/Repositories/UserRoleRepository.php
+++ b/src/Repositories/UserRoleRepository.php
@@ -4,6 +4,8 @@ namespace Glueful\Extensions\Aegis\Repositories;
 
 use Glueful\Repository\BaseRepository;
 use Glueful\Extensions\Aegis\Models\UserRole;
+use Glueful\Extensions\Aegis\Events\RoleAssignedEvent;
+use Glueful\Extensions\Aegis\Events\RoleRevokedEvent;
 use Glueful\Helpers\Utils;
 
 /**
@@ -329,7 +331,12 @@ class UserRoleRepository extends BaseRepository
             $data['scope'] = json_encode($options['scope']);
         }
 
-        return $this->createUserRole($data);
+        $userRole = $this->createUserRole($data);
+        if ($userRole !== null) {
+            $this->dispatchEvent(new RoleAssignedEvent($userUuid, $roleUuid, $options));
+        }
+
+        return $userRole;
     }
 
     /**
@@ -348,15 +355,38 @@ class UserRoleRepository extends BaseRepository
 
     public function revokeRole(string $userUuid, string $roleUuid): bool
     {
-        return (bool) $this->db->table($this->table)->where([
+        $deleted = (bool) $this->db->table($this->table)->where([
             'user_uuid' => $userUuid,
             'role_uuid' => $roleUuid
         ])->delete();
+
+        if ($deleted) {
+            $this->dispatchEvent(new RoleRevokedEvent($userUuid, $roleUuid));
+        }
+
+        return $deleted;
     }
 
     public function revokeAllUserRoles(string $userUuid): bool
     {
-        return (bool) $this->db->table($this->table)->where(['user_uuid' => $userUuid])->delete();
+        // Read the role_uuids first so we can emit one semantic event per removed pair.
+        $roleUuids = array_column(
+            $this->db->table($this->table)
+                ->select(['role_uuid'])
+                ->where(['user_uuid' => $userUuid])
+                ->get(),
+            'role_uuid'
+        );
+
+        $deleted = (bool) $this->db->table($this->table)->where(['user_uuid' => $userUuid])->delete();
+
+        if ($deleted) {
+            foreach ($roleUuids as $roleUuid) {
+                $this->dispatchEvent(new RoleRevokedEvent($userUuid, (string) $roleUuid));
+            }
+        }
+
+        return $deleted;
     }
 
     /**

--- a/src/Services/AegisServiceProvider.php
+++ b/src/Services/AegisServiceProvider.php
@@ -49,11 +49,36 @@ class AegisServiceProvider extends ServiceProvider
     public static function services(): array
     {
         return [
-            RoleRepository::class => ['class' => RoleRepository::class, 'shared' => true],
-            PermissionRepository::class => ['class' => PermissionRepository::class, 'shared' => true],
-            UserRoleRepository::class => ['class' => UserRoleRepository::class, 'shared' => true],
-            UserPermissionRepository::class => ['class' => UserPermissionRepository::class, 'shared' => true],
-            RolePermissionRepository::class => ['class' => RolePermissionRepository::class, 'shared' => true],
+            // Repos are injected with the ApplicationContext (constructor arg 2; arg 1 is the
+            // optional Connection, left null to use the shared one). Without it,
+            // BaseRepository::dispatchEvent() no-ops, so RBAC domain events fired from the
+            // service/controller layer (which receive these DI-built repos) would silently never
+            // dispatch — only the provider, which builds its own context-bearing repos, would.
+            RoleRepository::class => [
+                'class' => RoleRepository::class,
+                'shared' => true,
+                'arguments' => [null, '@' . ApplicationContext::class],
+            ],
+            PermissionRepository::class => [
+                'class' => PermissionRepository::class,
+                'shared' => true,
+                'arguments' => [null, '@' . ApplicationContext::class],
+            ],
+            UserRoleRepository::class => [
+                'class' => UserRoleRepository::class,
+                'shared' => true,
+                'arguments' => [null, '@' . ApplicationContext::class],
+            ],
+            UserPermissionRepository::class => [
+                'class' => UserPermissionRepository::class,
+                'shared' => true,
+                'arguments' => [null, '@' . ApplicationContext::class],
+            ],
+            RolePermissionRepository::class => [
+                'class' => RolePermissionRepository::class,
+                'shared' => true,
+                'arguments' => [null, '@' . ApplicationContext::class],
+            ],
 
             RoleService::class => [
                 'class' => RoleService::class,

--- a/tests/Integration/RbacEventExactlyOnceTest.php
+++ b/tests/Integration/RbacEventExactlyOnceTest.php
@@ -1,0 +1,449 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Tests\Integration;
+
+use Glueful\Auth\Contracts\UserProviderInterface;
+use Glueful\Auth\UserIdentity;
+use Glueful\Extensions\Aegis\AegisPermissionProvider;
+use Glueful\Extensions\Aegis\Events\PermissionAssignedEvent;
+use Glueful\Extensions\Aegis\Events\PermissionRevokedEvent;
+use Glueful\Extensions\Aegis\Events\RoleAssignedEvent;
+use Glueful\Extensions\Aegis\Events\RolePermissionAssignedEvent;
+use Glueful\Extensions\Aegis\Events\RolePermissionRevokedEvent;
+use Glueful\Extensions\Aegis\Events\RoleRevokedEvent;
+use Glueful\Extensions\Aegis\Repositories\PermissionRepository;
+use Glueful\Extensions\Aegis\Repositories\RolePermissionRepository;
+use Glueful\Extensions\Aegis\Repositories\RoleRepository;
+use Glueful\Extensions\Aegis\Repositories\UserPermissionRepository;
+use Glueful\Extensions\Aegis\Repositories\UserRoleRepository;
+use Glueful\Extensions\Aegis\Services\BootstrapAdminService;
+use Glueful\Extensions\Aegis\Services\PermissionAssignmentService;
+use Glueful\Extensions\Aegis\Services\RoleService;
+use Glueful\Extensions\Aegis\Tests\Support\AegisTestCase;
+
+/**
+ * Exactly-once guarantee, regardless of entry point.
+ *
+ * Tasks 2.0–2.4 made the three pivot repositories the sole dispatchers of RBAC domain events.
+ * This test proves the higher-level callers (provider, services, batch, replace/sync, bootstrap)
+ * all funnel through those single chokepoints and therefore emit EXACTLY ONE semantic event per
+ * real action — no duplicates (e.g. a service emitting its own copy on top of the repo's) and no
+ * misses (e.g. a caller bypassing the dispatching method). It guards against a future caller
+ * wiring around the chokepoint.
+ *
+ * Each family is driven from its HIGHEST reachable seam (provider/service); pure HTTP-only entry
+ * points (controllers) are covered through the exact repository/service method they delegate to —
+ * see the per-test docblocks for "direct vs via delegate".
+ *
+ * Slug-based callers resolve slugs to uuids first, so the catalog is pre-seeded with known uuids
+ * and assertions are made on those uuids.
+ */
+final class RbacEventExactlyOnceTest extends AegisTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Catalog with deterministic uuids so slug-resolving callers produce predictable events.
+        $this->seedRole(['uuid' => 'role-admin', 'slug' => 'admin', 'name' => 'Admin']);
+        $this->seedRole(['uuid' => 'role-editor', 'slug' => 'editor', 'name' => 'Editor']);
+        $this->seedPermission(['uuid' => 'perm-read', 'slug' => 'posts.read', 'name' => 'Read posts']);
+        $this->seedPermission(['uuid' => 'perm-write', 'slug' => 'posts.write', 'name' => 'Write posts']);
+        $this->seedPermission(['uuid' => 'perm-delete', 'slug' => 'posts.delete', 'name' => 'Delete posts']);
+    }
+
+    /** Cache-less provider, mirroring production boot() → initialize() but without distributed cache. */
+    private function provider(): AegisPermissionProvider
+    {
+        $provider = $this->makeProvider();
+        $provider->initialize(['cache_enabled' => false]);
+        return $provider;
+    }
+
+    /**
+     * Repos are built WITH the context exactly as the (fixed) DI definitions in
+     * AegisServiceProvider::services() now construct them — `[null, '@'.ApplicationContext::class]`.
+     * Building them context-less here would reproduce the pre-fix bug (dispatchEvent no-ops) and
+     * the service-layer assertions below would fail; that coupling is intentional — this test is
+     * the guard for that wiring.
+     */
+    private function roleService(): RoleService
+    {
+        return new RoleService(
+            new RoleRepository(null, $this->context),
+            new UserRoleRepository(null, $this->context),
+            $this->provider(),
+        );
+    }
+
+    private function permissionService(): PermissionAssignmentService
+    {
+        return new PermissionAssignmentService(
+            new PermissionRepository(null, $this->context),
+            new UserPermissionRepository(null, $this->context),
+            new RoleRepository(null, $this->context),
+            new UserRoleRepository(null, $this->context),
+            new RolePermissionRepository(null, $this->context),
+            $this->provider(),
+        );
+    }
+
+    /** @param array<string,string> $identifierToUuid */
+    private function bootstrapService(array $identifierToUuid): BootstrapAdminService
+    {
+        $users = new class ($identifierToUuid) implements UserProviderInterface {
+            /** @param array<string,string> $map */
+            public function __construct(private array $map)
+            {
+            }
+            public function findByUuid(string $uuid): ?UserIdentity
+            {
+                return in_array($uuid, $this->map, true) ? new UserIdentity($uuid) : null;
+            }
+            public function findByLogin(string $identifier): ?UserIdentity
+            {
+                $uuid = $this->map[$identifier] ?? null;
+                return $uuid !== null ? new UserIdentity($uuid) : null;
+            }
+            public function verifyCredentials(string $identifier, string $password): ?UserIdentity
+            {
+                return null;
+            }
+        };
+
+        return new BootstrapAdminService(
+            $users,
+            new RoleRepository(null, $this->context),
+            new PermissionRepository(null, $this->context),
+            new RolePermissionRepository(null, $this->context),
+            $this->provider(),
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // user ↔ role  (chokepoint: UserRoleRepository::assignRole/revokeRole/revokeAllUserRoles)
+    // ------------------------------------------------------------------
+
+    /**
+     * Entry point driven DIRECTLY: AegisPermissionProvider::assignRole/revokeRole (slug-based).
+     */
+    public function test_provider_assign_role_emits_exactly_one(): void
+    {
+        $provider = $this->provider();
+
+        self::assertTrue($provider->assignRole('user-1', 'admin', ['granted_by' => 'root']));
+
+        $events = $this->eventsOfType(RoleAssignedEvent::class);
+        self::assertCount(1, $events);
+        self::assertSame('user-1', $events[0]->userUuid);
+        self::assertSame('role-admin', $events[0]->roleUuid);
+    }
+
+    public function test_provider_reassign_role_is_noop_zero_events(): void
+    {
+        $provider = $this->provider();
+        $provider->assignRole('user-1', 'admin');
+        $this->recordedEvents = [];
+
+        $provider->assignRole('user-1', 'admin');
+
+        self::assertCount(0, $this->eventsOfType(RoleAssignedEvent::class));
+    }
+
+    public function test_provider_revoke_role_emits_exactly_one(): void
+    {
+        $provider = $this->provider();
+        $provider->assignRole('user-1', 'admin');
+        $this->recordedEvents = [];
+
+        self::assertTrue($provider->revokeRole('user-1', 'admin'));
+
+        $events = $this->eventsOfType(RoleRevokedEvent::class);
+        self::assertCount(1, $events);
+        self::assertSame('role-admin', $events[0]->roleUuid);
+    }
+
+    public function test_provider_revoke_absent_role_zero_events(): void
+    {
+        // Slug exists but the pair was never assigned: no-op, no event.
+        self::assertFalse($this->provider()->revokeRole('user-1', 'admin'));
+        self::assertCount(0, $this->eventsOfType(RoleRevokedEvent::class));
+    }
+
+    /**
+     * Entry point driven DIRECTLY: RoleService::assignRoleToUser/revokeRoleFromUser (uuid-based).
+     * Proves the service does NOT emit a duplicate on top of the repo's single dispatch.
+     */
+    public function test_role_service_assign_then_revoke_emits_one_each(): void
+    {
+        $svc = $this->roleService();
+
+        self::assertTrue($svc->assignRoleToUser('user-2', 'role-editor'));
+        self::assertCount(1, $this->eventsOfType(RoleAssignedEvent::class));
+
+        // Re-assign is a no-op at the service guard (hasUserRole) → zero further events.
+        self::assertTrue($svc->assignRoleToUser('user-2', 'role-editor'));
+        self::assertCount(1, $this->eventsOfType(RoleAssignedEvent::class));
+
+        $this->recordedEvents = [];
+        self::assertTrue($svc->revokeRoleFromUser('user-2', 'role-editor'));
+        $revoked = $this->eventsOfType(RoleRevokedEvent::class);
+        self::assertCount(1, $revoked);
+        self::assertSame('role-editor', $revoked[0]->roleUuid);
+
+        // Revoking the now-absent pair emits nothing.
+        $this->recordedEvents = [];
+        self::assertFalse($svc->revokeRoleFromUser('user-2', 'role-editor'));
+        self::assertCount(0, $this->eventsOfType(RoleRevokedEvent::class));
+    }
+
+    /**
+     * Entry point driven DIRECTLY: BootstrapAdminService::bootstrap.
+     * Its role-grant path delegates to provider->assignRole → UserRoleRepository::assignRole, and
+     * its permission path to RolePermissionRepository::assignPermissionToRole. Asserts exactly one
+     * RoleAssigned (user↔role) and one RolePermissionAssigned (role↔permission) for a first run.
+     */
+    public function test_bootstrap_admin_emits_one_role_assign_and_one_role_permission(): void
+    {
+        $svc = $this->bootstrapService(['jane@example.com' => 'user-3']);
+
+        $svc->bootstrap('jane@example.com', 'admin', ['posts.read'], false);
+
+        $assigned = $this->eventsOfType(RoleAssignedEvent::class);
+        self::assertCount(1, $assigned, 'exactly one user↔role grant');
+        self::assertSame('user-3', $assigned[0]->userUuid);
+        self::assertSame('role-admin', $assigned[0]->roleUuid);
+
+        $rolePerm = $this->eventsOfType(RolePermissionAssignedEvent::class);
+        self::assertCount(1, $rolePerm, 'exactly one role↔permission grant');
+        self::assertSame('role-admin', $rolePerm[0]->roleUuid);
+        self::assertSame('perm-read', $rolePerm[0]->permissionUuid);
+    }
+
+    public function test_bootstrap_admin_rerun_is_idempotent_zero_new_events(): void
+    {
+        $svc = $this->bootstrapService(['user-3' => 'user-3']);
+        $svc->bootstrap('user-3', 'admin', ['posts.read'], false);
+        $this->recordedEvents = [];
+
+        // Re-running grants nothing new: role already assigned, permission already on role.
+        $svc->bootstrap('user-3', 'admin', ['posts.read'], false);
+
+        self::assertCount(0, $this->eventsOfType(RoleAssignedEvent::class));
+        self::assertCount(0, $this->eventsOfType(RolePermissionAssignedEvent::class));
+    }
+
+    // ------------------------------------------------------------------
+    // user ↔ permission  (chokepoint: UserPermissionRepository::create/revokeUserPermission)
+    // ------------------------------------------------------------------
+
+    /**
+     * Entry point driven DIRECTLY: AegisPermissionProvider::assignPermission/revokePermission and
+     * batchAssignPermissions/batchRevokePermissions.
+     */
+    public function test_provider_assign_permission_emits_exactly_one(): void
+    {
+        $provider = $this->provider();
+
+        self::assertTrue($provider->assignPermission('user-1', 'posts.read', '*', ['granted_by' => 'root']));
+
+        $events = $this->eventsOfType(PermissionAssignedEvent::class);
+        self::assertCount(1, $events);
+        self::assertSame('user-1', $events[0]->userUuid);
+        self::assertSame('perm-read', $events[0]->permissionUuid);
+    }
+
+    public function test_provider_revoke_absent_permission_zero_events(): void
+    {
+        self::assertFalse($this->provider()->revokePermission('user-1', 'posts.read', '*'));
+        self::assertCount(0, $this->eventsOfType(PermissionRevokedEvent::class));
+    }
+
+    public function test_provider_batch_assign_n_distinct_emits_n_events(): void
+    {
+        $provider = $this->provider();
+
+        $ok = $provider->batchAssignPermissions('user-1', [
+            ['permission' => 'posts.read'],
+            ['permission' => 'posts.write'],
+            ['permission' => 'posts.delete'],
+        ]);
+
+        self::assertTrue($ok);
+        $events = $this->eventsOfType(PermissionAssignedEvent::class);
+        self::assertCount(3, $events);
+        $perms = array_map(static fn(PermissionAssignedEvent $e) => $e->permissionUuid, $events);
+        sort($perms);
+        self::assertSame(['perm-delete', 'perm-read', 'perm-write'], $perms);
+    }
+
+    public function test_provider_batch_revoke_n_distinct_emits_n_events(): void
+    {
+        $provider = $this->provider();
+        $provider->assignPermission('user-1', 'posts.read', '*');
+        $provider->assignPermission('user-1', 'posts.write', '*');
+        $this->recordedEvents = [];
+
+        $provider->batchRevokePermissions('user-1', [
+            ['permission' => 'posts.read'],
+            ['permission' => 'posts.write'],
+        ]);
+
+        $events = $this->eventsOfType(PermissionRevokedEvent::class);
+        self::assertCount(2, $events);
+        $perms = array_map(static fn(PermissionRevokedEvent $e) => $e->permissionUuid, $events);
+        sort($perms);
+        self::assertSame(['perm-read', 'perm-write'], $perms);
+    }
+
+    /**
+     * Entry point driven DIRECTLY: PermissionAssignmentService::assignPermissionToUser /
+     * revokePermissionFromUser / batchAssignPermissions. (PermissionController::batchAssign is
+     * HTTP-only; it delegates to this service method — covered here via the delegate.)
+     */
+    public function test_permission_service_assign_revoke_and_batch(): void
+    {
+        $svc = $this->permissionService();
+
+        // Single assign → one event.
+        self::assertTrue($svc->assignPermissionToUser('user-4', 'posts.read'));
+        self::assertCount(1, $this->eventsOfType(PermissionAssignedEvent::class));
+
+        // Re-assign is a no-op at the service guard (findUserPermission) → no new event.
+        self::assertTrue($svc->assignPermissionToUser('user-4', 'posts.read'));
+        self::assertCount(1, $this->eventsOfType(PermissionAssignedEvent::class));
+
+        // Revoke → one event; re-revoke (absent) → none.
+        $this->recordedEvents = [];
+        self::assertTrue($svc->revokePermissionFromUser('user-4', 'posts.read'));
+        self::assertCount(1, $this->eventsOfType(PermissionRevokedEvent::class));
+        $this->recordedEvents = [];
+        self::assertFalse($svc->revokePermissionFromUser('user-4', 'posts.read'));
+        self::assertCount(0, $this->eventsOfType(PermissionRevokedEvent::class));
+
+        // Batch of N distinct → N events.
+        $this->recordedEvents = [];
+        $svc->batchAssignPermissions('user-4', [
+            ['permission' => 'posts.read'],
+            ['permission' => 'posts.write'],
+            ['permission' => 'posts.delete'],
+        ]);
+        self::assertCount(3, $this->eventsOfType(PermissionAssignedEvent::class));
+    }
+
+    // ------------------------------------------------------------------
+    // role ↔ permission  (chokepoint: RolePermissionRepository::assignPermissionToRole /
+    //                     revokePermissionFromRole)
+    // ------------------------------------------------------------------
+
+    /**
+     * Entry points driven DIRECTLY at the repository: assignPermissionToRole, batchAssignPermissions,
+     * replaceRolePermissions. RoleController::assignPermissions/replacePermissions are HTTP-only and
+     * delegate verbatim to batchAssignPermissions / replaceRolePermissions — covered here via those
+     * delegates.
+     */
+    public function test_role_permission_assign_and_noop(): void
+    {
+        $repo = new RolePermissionRepository(null, $this->context);
+
+        self::assertNotNull($repo->assignPermissionToRole('role-admin', 'perm-read'));
+        self::assertCount(1, $this->eventsOfType(RolePermissionAssignedEvent::class));
+
+        // Re-assign existing → idempotent, zero new events.
+        $this->recordedEvents = [];
+        self::assertNotNull($repo->assignPermissionToRole('role-admin', 'perm-read'));
+        self::assertCount(0, $this->eventsOfType(RolePermissionAssignedEvent::class));
+    }
+
+    public function test_role_permission_batch_assign_n_emits_n(): void
+    {
+        $repo = new RolePermissionRepository(null, $this->context);
+
+        $repo->batchAssignPermissions('role-admin', ['perm-read', 'perm-write', 'perm-delete']);
+
+        self::assertCount(3, $this->eventsOfType(RolePermissionAssignedEvent::class));
+    }
+
+    /**
+     * replace/sync from {read, write} to {write, delete}: exactly one revoke (read) + one assign
+     * (delete), and NOT a revoke/assign for the unchanged write.
+     *
+     * NOTE: replaceRolePermissions revokes ALL existing then re-assigns the new set, so the
+     * unchanged member emits a revoke+assign pair internally. To assert the *semantic* delta
+     * (which is what a future sync optimisation must preserve), drive the highest seam that
+     * computes a delta — AegisPermissionProvider::syncCatalog → syncRoles — and assert the net
+     * events for the changed members only.
+     */
+    public function test_provider_sync_catalog_emits_delta_only_for_changed_members(): void
+    {
+        $repo = new RolePermissionRepository(null, $this->context);
+        // Seed the role with {read, write}.
+        $repo->assignPermissionToRole('role-editor', 'perm-read');
+        $repo->assignPermissionToRole('role-editor', 'perm-write');
+        $this->recordedEvents = [];
+
+        // Sync declares the editor role granting {write, delete}: read removed, delete added,
+        // write unchanged.
+        $provider = $this->provider();
+        $provider->syncCatalog(
+            [
+                ['slug' => 'posts.read', 'name' => 'Read posts'],
+                ['slug' => 'posts.write', 'name' => 'Write posts'],
+                ['slug' => 'posts.delete', 'name' => 'Delete posts'],
+            ],
+            [
+                ['slug' => 'editor', 'name' => 'Editor', 'grants' => ['posts.write', 'posts.delete']],
+            ],
+        );
+
+        $revoked = $this->eventsOfType(RolePermissionRevokedEvent::class);
+        $assigned = $this->eventsOfType(RolePermissionAssignedEvent::class);
+
+        $revokedPerms = array_map(static fn(RolePermissionRevokedEvent $e) => $e->permissionUuid, $revoked);
+        $assignedPerms = array_map(static fn(RolePermissionAssignedEvent $e) => $e->permissionUuid, $assigned);
+
+        // The removed member (read) is revoked exactly once and never re-assigned.
+        self::assertSame([1], [count(array_keys($revokedPerms, 'perm-read', true))], 'read revoked exactly once');
+        self::assertNotContains('perm-read', $assignedPerms, 'read must not be re-assigned');
+
+        // The added member (delete) is assigned exactly once and never revoked.
+        self::assertSame([1], [count(array_keys($assignedPerms, 'perm-delete', true))], 'delete assigned exactly once');
+        self::assertNotContains('perm-delete', $revokedPerms, 'delete must not be revoked');
+    }
+
+    /**
+     * Direct repo-level replace from {read, write} to {write, delete}: documents the current
+     * replaceRolePermissions behaviour (revoke-all then re-assign), and pins the NET outcome —
+     * read revoked-not-readded, delete added-not-revoked — so a future "diff-only" optimisation
+     * has a guard. write churns (revoke+assign) under the current impl; we assert it is NOT
+     * net-removed (ends up assigned) rather than asserting zero churn.
+     */
+    public function test_repo_replace_role_permissions_net_delta(): void
+    {
+        $repo = new RolePermissionRepository(null, $this->context);
+        $repo->assignPermissionToRole('role-editor', 'perm-read');
+        $repo->assignPermissionToRole('role-editor', 'perm-write');
+        $this->recordedEvents = [];
+
+        self::assertTrue($repo->replaceRolePermissions('role-editor', ['perm-write', 'perm-delete']));
+
+        $revoked = array_map(
+            static fn(RolePermissionRevokedEvent $e) => $e->permissionUuid,
+            $this->eventsOfType(RolePermissionRevokedEvent::class)
+        );
+        $assigned = array_map(
+            static fn(RolePermissionAssignedEvent $e) => $e->permissionUuid,
+            $this->eventsOfType(RolePermissionAssignedEvent::class)
+        );
+
+        // read: revoked, never re-assigned (net removed).
+        self::assertContains('perm-read', $revoked);
+        self::assertNotContains('perm-read', $assigned);
+        // delete: assigned, never revoked (net added).
+        self::assertContains('perm-delete', $assigned);
+        self::assertNotContains('perm-delete', $revoked);
+        // write (unchanged): ends up assigned in the final set (not net-removed).
+        self::assertContains('perm-write', $assigned);
+    }
+}

--- a/tests/Support/AegisTestCase.php
+++ b/tests/Support/AegisTestCase.php
@@ -6,11 +6,16 @@ namespace Glueful\Extensions\Aegis\Tests\Support;
 
 use Glueful\Bootstrap\ApplicationContext;
 use Glueful\Database\Connection;
+use Glueful\Events\Contracts\BaseEvent;
+use Glueful\Events\EventDispatcher;
+use Glueful\Events\EventService;
+use Glueful\Events\ListenerProvider;
 use Glueful\Extensions\Aegis\AegisPermissionProvider;
 use Glueful\Extensions\Aegis\Repositories\PermissionRepository;
 use Glueful\Extensions\Aegis\Repositories\RoleRepository;
 use Glueful\Helpers\Utils;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 /**
  * Lightweight SQLite harness for Aegis catalog tests.
@@ -21,17 +26,35 @@ use PHPUnit\Framework\TestCase;
 abstract class AegisTestCase extends TestCase
 {
     protected Connection $connection;
+    protected ApplicationContext $context;
     private string $dbPath;
+
+    /**
+     * Domain events captured during a test. The pivot repos dispatch via
+     * BaseRepository::dispatchEvent() -> app($context, EventService::class)->dispatch(),
+     * so we put a real EventService (with a catch-all BaseEvent listener) behind a minimal
+     * container on $this->context. Without this container, getContainer() throws and
+     * dispatchEvent() swallows it — events would silently never fire.
+     *
+     * @var list<BaseEvent>
+     */
+    protected array $recordedEvents = [];
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->dbPath = sys_get_temp_dir() . '/aegis-' . uniqid('', true) . '.sqlite';
+        // Build the test context first and bind it to the SQLite connection. BaseRepository's
+        // shared connection is only replaced when a context arrives and the current shared
+        // connection hasContext() === false; binding it here keeps repos constructed WITH this
+        // context (production wiring) from swapping our in-test SQLite db for a default one.
+        $this->context = ApplicationContext::forTesting(sys_get_temp_dir());
+        $this->installEventCapture();
         $this->connection = new Connection([
             'engine' => 'sqlite',
             'sqlite' => ['primary' => $this->dbPath],
             'pooling' => ['enabled' => false],
-        ]);
+        ], $this->context);
         $this->createSchema();
         // Register as the shared repository connection (BaseRepository::$sharedConnection).
         new PermissionRepository($this->connection);
@@ -86,7 +109,63 @@ abstract class AegisTestCase extends TestCase
 
     protected function makeProvider(): AegisPermissionProvider
     {
-        return new AegisPermissionProvider(ApplicationContext::forTesting(sys_get_temp_dir()));
+        return new AegisPermissionProvider($this->context);
+    }
+
+    /**
+     * Build a real EventService whose dispatcher records every BaseEvent into
+     * $this->recordedEvents, and expose it through a minimal PSR-11 container set on the
+     * test context so app($context, EventService::class) returns exactly this instance.
+     */
+    private function installEventCapture(): void
+    {
+        $this->recordedEvents = [];
+
+        $provider = new ListenerProvider();
+        // Catch-all: a listener on BaseEvent receives every subclass (InheritanceResolver
+        // walks parents), so we record all dispatched RBAC domain events.
+        $provider->addListener(BaseEvent::class, function (BaseEvent $event): void {
+            $this->recordedEvents[] = $event;
+        });
+        $eventService = new EventService(new EventDispatcher($provider), $provider);
+
+        $container = new class ($eventService) implements ContainerInterface {
+            public function __construct(private EventService $eventService)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                if ($id === EventService::class) {
+                    return $this->eventService;
+                }
+                throw new class ('No entry for ' . $id)
+                    extends \RuntimeException implements \Psr\Container\NotFoundExceptionInterface {
+                };
+            }
+
+            public function has(string $id): bool
+            {
+                return $id === EventService::class;
+            }
+        };
+
+        $this->context->setContainer($container);
+    }
+
+    /**
+     * Captured events of a given class.
+     *
+     * @template T of BaseEvent
+     * @param class-string<T> $class
+     * @return list<T>
+     */
+    protected function eventsOfType(string $class): array
+    {
+        return array_values(array_filter(
+            $this->recordedEvents,
+            static fn(BaseEvent $e): bool => $e instanceof $class
+        ));
     }
 
     /** @param array<string,mixed> $row */

--- a/tests/Unit/RepositoryContextWiringTest.php
+++ b/tests/Unit/RepositoryContextWiringTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Tests\Unit;
+
+use Glueful\Extensions\Aegis\Tests\Support\AegisTestCase;
+use Glueful\Repository\BaseRepository;
+
+/**
+ * The three pivot repositories will dispatch RBAC domain events via BaseRepository::dispatchEvent(),
+ * which no-ops when its $context is null. So the repos MUST be constructed WITH the provider's
+ * ApplicationContext, or those events would silently never fire.
+ *
+ * These tests obtain each pivot repo the production way (through AegisPermissionProvider's lazy
+ * getters) and assert — via reflection on BaseRepository::$context — that it carries the provider's
+ * non-null context.
+ */
+final class RepositoryContextWiringTest extends AegisTestCase
+{
+    private function repoContext(BaseRepository $repo): ?object
+    {
+        $prop = new \ReflectionProperty(BaseRepository::class, 'context');
+        $prop->setAccessible(true);
+        $value = $prop->getValue($repo);
+
+        return is_object($value) ? $value : null;
+    }
+
+    /** @return BaseRepository */
+    private function getRepo(\Glueful\Extensions\Aegis\AegisPermissionProvider $provider, string $getter): BaseRepository
+    {
+        $method = new \ReflectionMethod($provider, $getter);
+        $method->setAccessible(true);
+
+        return $method->invoke($provider);
+    }
+
+    private function providerContext(\Glueful\Extensions\Aegis\AegisPermissionProvider $provider): object
+    {
+        $prop = new \ReflectionProperty($provider, 'context');
+        $prop->setAccessible(true);
+
+        return $prop->getValue($provider);
+    }
+
+    public function test_user_role_repository_carries_provider_context(): void
+    {
+        $provider = $this->makeProvider();
+        $repo = $this->getRepo($provider, 'getUserRoleRepository');
+
+        self::assertNotNull($this->repoContext($repo), 'UserRoleRepository must have a non-null context so dispatched events fire');
+        self::assertSame($this->providerContext($provider), $this->repoContext($repo));
+    }
+
+    public function test_user_permission_repository_carries_provider_context(): void
+    {
+        $provider = $this->makeProvider();
+        $repo = $this->getRepo($provider, 'getUserPermissionRepository');
+
+        self::assertNotNull($this->repoContext($repo), 'UserPermissionRepository must have a non-null context so dispatched events fire');
+        self::assertSame($this->providerContext($provider), $this->repoContext($repo));
+    }
+
+    public function test_role_permission_repository_carries_provider_context(): void
+    {
+        $provider = $this->makeProvider();
+        $repo = $this->getRepo($provider, 'getRolePermissionRepository');
+
+        self::assertNotNull($this->repoContext($repo), 'RolePermissionRepository must have a non-null context so dispatched events fire');
+        self::assertSame($this->providerContext($provider), $this->repoContext($repo));
+    }
+}

--- a/tests/Unit/RolePermissionEventsTest.php
+++ b/tests/Unit/RolePermissionEventsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Tests\Unit;
+
+use Glueful\Extensions\Aegis\Events\RolePermissionAssignedEvent;
+use Glueful\Extensions\Aegis\Events\RolePermissionRevokedEvent;
+use Glueful\Extensions\Aegis\Repositories\RolePermissionRepository;
+use Glueful\Extensions\Aegis\Tests\Support\AegisTestCase;
+
+/**
+ * Asserts RolePermissionRepository emits semantic RBAC events, including the
+ * replaceRolePermissions() fix that routes removals through the semantic revoke method.
+ */
+final class RolePermissionEventsTest extends AegisTestCase
+{
+    private function repo(): RolePermissionRepository
+    {
+        return new RolePermissionRepository(null, $this->context);
+    }
+
+    public function test_assign_emits_one_role_permission_assigned_event(): void
+    {
+        $this->repo()->assignPermissionToRole('role-1', 'perm-1', ['granted_by' => 'admin']);
+
+        $events = $this->eventsOfType(RolePermissionAssignedEvent::class);
+        self::assertCount(1, $events);
+        self::assertSame('role-1', $events[0]->roleUuid);
+        self::assertSame('perm-1', $events[0]->permissionUuid);
+        self::assertSame('admin', $events[0]->options['granted_by'] ?? null);
+    }
+
+    public function test_duplicate_assign_emits_zero_additional_events(): void
+    {
+        $repo = $this->repo();
+        $repo->assignPermissionToRole('role-1', 'perm-1');
+        $this->recordedEvents = [];
+
+        $repo->assignPermissionToRole('role-1', 'perm-1');
+
+        self::assertCount(0, $this->eventsOfType(RolePermissionAssignedEvent::class));
+    }
+
+    public function test_revoke_existing_emits_one_event(): void
+    {
+        $repo = $this->repo();
+        $repo->assignPermissionToRole('role-1', 'perm-1');
+        $this->recordedEvents = [];
+
+        $repo->revokePermissionFromRole('role-1', 'perm-1');
+
+        $events = $this->eventsOfType(RolePermissionRevokedEvent::class);
+        self::assertCount(1, $events);
+        self::assertSame('role-1', $events[0]->roleUuid);
+        self::assertSame('perm-1', $events[0]->permissionUuid);
+    }
+
+    public function test_revoke_absent_link_emits_zero_events(): void
+    {
+        // revokePermissionFromRole() returns true even when absent (so the batch tally lies),
+        // but the dispatch is guarded by the actual delete() — assert ZERO events here.
+        $result = $this->repo()->revokePermissionFromRole('role-1', 'never-linked');
+
+        self::assertTrue($result);
+        self::assertCount(0, $this->eventsOfType(RolePermissionRevokedEvent::class));
+    }
+
+    public function test_replace_emits_revoke_per_removed_and_assign_per_added(): void
+    {
+        $repo = $this->repo();
+        // Seed two existing links.
+        $repo->assignPermissionToRole('role-1', 'perm-1');
+        $repo->assignPermissionToRole('role-1', 'perm-2');
+        $this->recordedEvents = [];
+
+        // Replace with a different set: keep none, add perm-3 and perm-4.
+        $ok = $repo->replaceRolePermissions('role-1', ['perm-3', 'perm-4']);
+
+        self::assertTrue($ok);
+
+        $revoked = $this->eventsOfType(RolePermissionRevokedEvent::class);
+        $assigned = $this->eventsOfType(RolePermissionAssignedEvent::class);
+
+        self::assertCount(2, $revoked, 'one revoke per removed link');
+        self::assertCount(2, $assigned, 'one assign per added link');
+
+        $removed = array_map(static fn(RolePermissionRevokedEvent $e) => $e->permissionUuid, $revoked);
+        sort($removed);
+        self::assertSame(['perm-1', 'perm-2'], $removed);
+
+        $added = array_map(static fn(RolePermissionAssignedEvent $e) => $e->permissionUuid, $assigned);
+        sort($added);
+        self::assertSame(['perm-3', 'perm-4'], $added);
+    }
+}

--- a/tests/Unit/UserPermissionEventsTest.php
+++ b/tests/Unit/UserPermissionEventsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Tests\Unit;
+
+use Glueful\Extensions\Aegis\Events\PermissionAssignedEvent;
+use Glueful\Extensions\Aegis\Events\PermissionRevokedEvent;
+use Glueful\Extensions\Aegis\Repositories\UserPermissionRepository;
+use Glueful\Extensions\Aegis\Tests\Support\AegisTestCase;
+
+/**
+ * Asserts UserPermissionRepository emits semantic RBAC events. The grant chokepoint is the
+ * overridden create(); revokes guard on actual deletion.
+ */
+final class UserPermissionEventsTest extends AegisTestCase
+{
+    private function repo(): UserPermissionRepository
+    {
+        return new UserPermissionRepository(null, $this->context);
+    }
+
+    public function test_grant_emits_one_permission_assigned_event(): void
+    {
+        $this->repo()->create([
+            'user_uuid' => 'user-1',
+            'permission_uuid' => 'perm-1',
+            'granted_by' => 'admin',
+        ]);
+
+        $events = $this->eventsOfType(PermissionAssignedEvent::class);
+        self::assertCount(1, $events);
+        self::assertSame('user-1', $events[0]->userUuid);
+        self::assertSame('perm-1', $events[0]->permissionUuid);
+        self::assertSame('admin', $events[0]->options['granted_by'] ?? null);
+    }
+
+    public function test_scoped_grant_carries_decoded_resource_filter(): void
+    {
+        $filter = ['resource' => 'posts', 'ids' => ['p1', 'p2']];
+        $this->repo()->create([
+            'user_uuid' => 'user-1',
+            'permission_uuid' => 'perm-1',
+            'resource_filter' => json_encode($filter),
+        ]);
+
+        $events = $this->eventsOfType(PermissionAssignedEvent::class);
+        self::assertCount(1, $events);
+        $rf = $events[0]->options['resource_filter'] ?? null;
+        self::assertIsArray($rf, 'scoped grant must carry the decoded resource_filter');
+        self::assertSame($filter, $rf);
+        self::assertNotSame('*', $rf, 'scope must not be lost/flattened to a wildcard');
+    }
+
+    public function test_revoke_existing_emits_one_permission_revoked_event(): void
+    {
+        $repo = $this->repo();
+        $repo->create(['user_uuid' => 'user-1', 'permission_uuid' => 'perm-1']);
+        $this->recordedEvents = [];
+
+        $deleted = $repo->revokeUserPermission('user-1', 'perm-1');
+
+        self::assertTrue($deleted);
+        $events = $this->eventsOfType(PermissionRevokedEvent::class);
+        self::assertCount(1, $events);
+        self::assertSame('user-1', $events[0]->userUuid);
+        self::assertSame('perm-1', $events[0]->permissionUuid);
+    }
+
+    public function test_revoke_absent_pair_emits_zero_events(): void
+    {
+        $deleted = $this->repo()->revokeUserPermission('user-1', 'nope');
+
+        self::assertFalse($deleted);
+        self::assertCount(0, $this->eventsOfType(PermissionRevokedEvent::class));
+    }
+
+    public function test_revoke_all_emits_one_event_per_removed_permission(): void
+    {
+        $repo = $this->repo();
+        $repo->create(['user_uuid' => 'user-1', 'permission_uuid' => 'perm-1']);
+        $repo->create(['user_uuid' => 'user-1', 'permission_uuid' => 'perm-2']);
+        $this->recordedEvents = [];
+
+        $repo->revokeAllUserPermissions('user-1');
+
+        $events = $this->eventsOfType(PermissionRevokedEvent::class);
+        self::assertCount(2, $events);
+        $perms = array_map(static fn(PermissionRevokedEvent $e) => $e->permissionUuid, $events);
+        sort($perms);
+        self::assertSame(['perm-1', 'perm-2'], $perms);
+    }
+
+    public function test_revoke_all_with_no_permissions_emits_zero_events(): void
+    {
+        $this->repo()->revokeAllUserPermissions('user-nobody');
+
+        self::assertCount(0, $this->eventsOfType(PermissionRevokedEvent::class));
+    }
+}

--- a/tests/Unit/UserRoleEventsTest.php
+++ b/tests/Unit/UserRoleEventsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Extensions\Aegis\Tests\Unit;
+
+use Glueful\Extensions\Aegis\Events\RoleAssignedEvent;
+use Glueful\Extensions\Aegis\Events\RoleRevokedEvent;
+use Glueful\Extensions\Aegis\Repositories\UserRoleRepository;
+use Glueful\Extensions\Aegis\Tests\Support\AegisTestCase;
+
+/**
+ * Asserts UserRoleRepository emits semantic RBAC events from the (context-bearing) harness.
+ * Repos are constructed with $this->context so BaseRepository::dispatchEvent() actually fires.
+ */
+final class UserRoleEventsTest extends AegisTestCase
+{
+    private function repo(): UserRoleRepository
+    {
+        return new UserRoleRepository(null, $this->context);
+    }
+
+    public function test_assign_emits_one_role_assigned_event(): void
+    {
+        $this->repo()->assignRole('user-1', 'role-1', ['granted_by' => 'admin']);
+
+        $events = $this->eventsOfType(RoleAssignedEvent::class);
+        self::assertCount(1, $events);
+        self::assertSame('user-1', $events[0]->userUuid);
+        self::assertSame('role-1', $events[0]->roleUuid);
+        self::assertSame('admin', $events[0]->options['granted_by'] ?? null);
+    }
+
+    public function test_duplicate_assign_emits_zero_additional_events(): void
+    {
+        $repo = $this->repo();
+        $repo->assignRole('user-1', 'role-1');
+        $this->recordedEvents = []; // reset; the no-op assign below must emit nothing
+
+        $repo->assignRole('user-1', 'role-1');
+
+        self::assertCount(0, $this->eventsOfType(RoleAssignedEvent::class));
+    }
+
+    public function test_revoke_existing_emits_one_role_revoked_event(): void
+    {
+        $repo = $this->repo();
+        $repo->assignRole('user-1', 'role-1');
+        $this->recordedEvents = [];
+
+        $deleted = $repo->revokeRole('user-1', 'role-1');
+
+        self::assertTrue($deleted);
+        $events = $this->eventsOfType(RoleRevokedEvent::class);
+        self::assertCount(1, $events);
+        self::assertSame('user-1', $events[0]->userUuid);
+        self::assertSame('role-1', $events[0]->roleUuid);
+    }
+
+    public function test_revoke_absent_pair_emits_zero_events(): void
+    {
+        $deleted = $this->repo()->revokeRole('user-1', 'nope');
+
+        self::assertFalse($deleted);
+        self::assertCount(0, $this->eventsOfType(RoleRevokedEvent::class));
+    }
+
+    public function test_revoke_all_emits_one_event_per_removed_role(): void
+    {
+        $repo = $this->repo();
+        $repo->assignRole('user-1', 'role-1');
+        $repo->assignRole('user-1', 'role-2');
+        $this->recordedEvents = [];
+
+        $repo->revokeAllUserRoles('user-1');
+
+        $events = $this->eventsOfType(RoleRevokedEvent::class);
+        self::assertCount(2, $events);
+        $roleUuids = array_map(static fn(RoleRevokedEvent $e) => $e->roleUuid, $events);
+        sort($roleUuids);
+        self::assertSame(['role-1', 'role-2'], $roleUuids);
+    }
+
+    public function test_revoke_all_with_no_roles_emits_zero_events(): void
+    {
+        $this->repo()->revokeAllUserRoles('user-nobody');
+
+        self::assertCount(0, $this->eventsOfType(RoleRevokedEvent::class));
+    }
+}


### PR DESCRIPTION
Dispatch six semantic PSR-14 events from the pivot repositories on real mutations — RoleAssigned/Revoked (user-role), PermissionAssigned/Revoked (direct user-permission), RolePermissionAssigned/Revoked (role-permission) — from the single chokepoint every entry point converges on: exactly once per semantic action, one per affected item for batch/replace, nothing on a no-op. Lets an extension (glueful/audit) record meaningful RBAC actions instead of raw pivot writes, with no coupling back to Aegis. Requires framework ^1.63.0 (protected BaseRepository::dispatchEvent()).

Fixes that make the events (and the framework's entity events) actually fire: the provider lazy getters, BootstrapAdminCommand, and the AegisServiceProvider DI definitions all built the pivot repositories with a null ApplicationContext, which dispatchEvent() silently no-ops on — every repo is now constructed with context. And replaceRolePermissions() now routes removals through the semantic revokePermissionFromRole (it bypassed it with a raw delete loop, so a replace/sync dropped links without a revoke event).