### PR TITLE
Reconcile role permissions by diff instead of full replace (v1.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-06-26
+
+### Changed
+- **`replaceRolePermissions()` now reconciles role grants by diff instead of revoke-all-then-reassign.**
+  Re-applying a role's permission set — via `permissions:sync` or editing a role in the admin UI — previously
+  revoked *every* existing grant and re-inserted the *entire* desired set, leaving a soft-delete tombstone per
+  grant and emitting a full `RolePermissionRevokedEvent` + `RolePermissionAssignedEvent` burst on every run,
+  even when nothing changed. It now diffs the desired set against the role's current **live** grants and touches
+  only the difference: revokes only removed links, assigns only new ones, and leaves unchanged grants alone. An
+  unchanged sync/edit now writes nothing and emits no events, so downstream audit / cache consumers see only
+  real changes (no more tombstone buildup or spurious churn). End-state semantics are unchanged — the role's
+  live grants still become exactly the supplied set — and duplicate UUIDs in the input are de-duplicated.
+
 ## [1.13.0] - 2026-06-25
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
             "name": "Aegis",
             "displayName": "Aegis",
             "description": "Modern, hierarchical role-based access control system",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "icon": "assets/icon.png",
             "galleryBanner": {
                 "color": "#2563EB",

--- a/src/Repositories/RolePermissionRepository.php
+++ b/src/Repositories/RolePermissionRepository.php
@@ -260,26 +260,48 @@ class RolePermissionRepository extends BaseRepository
     }
 
     /**
-     * Replace all permissions for a role
+     * Replace a role's permissions so its live grants become exactly $permissionUuids.
+     *
+     * Reconciles by diffing against the current live set: only genuinely added or removed
+     * links are written, so re-applying an unchanged set is a no-op — no soft-delete
+     * tombstones and no revoke/assign event churn. Each real change still flows through the
+     * semantic revoke/assign methods, so RolePermission{Revoked,Assigned}Event fire for
+     * exactly the links that changed. Comparison is by permission UUID only (these callers
+     * pass bare UUID lists); per-grant option changes on an unchanged link are not detected.
      *
      * @param string $roleUuid Role UUID
-     * @param list<string> $permissionUuids New permission UUIDs
-     * @param array<string, mixed> $options Assignment options
+     * @param list<string> $permissionUuids Desired permission UUIDs
+     * @param array<string, mixed> $options Assignment options applied to newly added links
      * @return bool Success status
      */
     public function replaceRolePermissions(string $roleUuid, array $permissionUuids, array $options = []): bool
     {
-        // Remove all existing permissions via the semantic method so each removed
-        // link emits a RolePermissionRevokedEvent (a raw delete() loop bypasses it).
-        $existing = $this->getRolePermissions($roleUuid);
-        foreach ($existing as $assignment) {
-            $this->revokePermissionFromRole($roleUuid, $assignment->getPermissionUuid());
+        $desired = array_values(array_unique($permissionUuids));
+
+        // getRolePermissions() reads through the soft-delete scope, so $current is the role's
+        // *live* permission set (tombstones excluded), deduped by permission UUID.
+        $current = [];
+        foreach ($this->getRolePermissions($roleUuid) as $assignment) {
+            $current[$assignment->getPermissionUuid()] = true;
+        }
+        $current = array_keys($current);
+
+        $failed = 0;
+
+        // Revoke only the links that are no longer desired.
+        foreach (array_diff($current, $desired) as $permissionUuid) {
+            if (!$this->revokePermissionFromRole($roleUuid, $permissionUuid)) {
+                $failed++;
+            }
         }
 
-        // Assign new permissions
-        $results = $this->batchAssignPermissions($roleUuid, $permissionUuids, $options);
+        // Assign only the genuinely new links; untouched links keep their existing rows.
+        $toAdd = array_values(array_diff($desired, $current));
+        if ($toAdd !== []) {
+            $failed += $this->batchAssignPermissions($roleUuid, $toAdd, $options)['failed'];
+        }
 
-        return $results['failed'] === 0;
+        return $failed === 0;
     }
 
     /**

--- a/tests/Integration/RbacEventExactlyOnceTest.php
+++ b/tests/Integration/RbacEventExactlyOnceTest.php
@@ -413,11 +413,10 @@ final class RbacEventExactlyOnceTest extends AegisTestCase
     }
 
     /**
-     * Direct repo-level replace from {read, write} to {write, delete}: documents the current
-     * replaceRolePermissions behaviour (revoke-all then re-assign), and pins the NET outcome —
-     * read revoked-not-readded, delete added-not-revoked — so a future "diff-only" optimisation
-     * has a guard. write churns (revoke+assign) under the current impl; we assert it is NOT
-     * net-removed (ends up assigned) rather than asserting zero churn.
+     * Direct repo-level replace from {read, write} to {write, delete}: replaceRolePermissions
+     * now reconciles by diff, so it touches ONLY the changed members — read is revoked, delete
+     * is assigned, and the unchanged write is left alone (no revoke/assign churn). Pins both the
+     * per-member event deltas and the final live grant set.
      */
     public function test_repo_replace_role_permissions_net_delta(): void
     {
@@ -443,7 +442,16 @@ final class RbacEventExactlyOnceTest extends AegisTestCase
         // delete: assigned, never revoked (net added).
         self::assertContains('perm-delete', $assigned);
         self::assertNotContains('perm-delete', $revoked);
-        // write (unchanged): ends up assigned in the final set (not net-removed).
-        self::assertContains('perm-write', $assigned);
+        // write (unchanged): left untouched — neither revoked nor re-assigned.
+        self::assertNotContains('perm-write', $revoked, 'unchanged grant is not revoked');
+        self::assertNotContains('perm-write', $assigned, 'unchanged grant is not re-assigned');
+
+        // Final live grant set is exactly {write, delete}.
+        $live = array_map(
+            static fn($a) => $a->getPermissionUuid(),
+            $repo->getRolePermissions('role-editor')
+        );
+        sort($live);
+        self::assertSame(['perm-delete', 'perm-write'], $live);
     }
 }

--- a/tests/Unit/RolePermissionEventsTest.php
+++ b/tests/Unit/RolePermissionEventsTest.php
@@ -93,4 +93,157 @@ final class RolePermissionEventsTest extends AegisTestCase
         sort($added);
         self::assertSame(['perm-3', 'perm-4'], $added);
     }
+
+    public function test_replace_with_identical_set_writes_nothing(): void
+    {
+        $repo = $this->repo();
+        $repo->assignPermissionToRole('role-1', 'perm-1');
+        $repo->assignPermissionToRole('role-1', 'perm-2');
+        $repo->assignPermissionToRole('role-1', 'perm-3');
+        $before = $this->liveLinks('role-1');
+        $this->recordedEvents = [];
+
+        $ok = $repo->replaceRolePermissions('role-1', ['perm-1', 'perm-2', 'perm-3']);
+
+        self::assertTrue($ok);
+        self::assertCount(0, $this->eventsOfType(RolePermissionAssignedEvent::class), 'no assigns for an unchanged set');
+        self::assertCount(0, $this->eventsOfType(RolePermissionRevokedEvent::class), 'no revokes for an unchanged set');
+        self::assertSame(0, $this->tombstoneCount('role-1'), 'no new soft-delete tombstones');
+        self::assertSame($before, $this->liveLinks('role-1'), 'live rows untouched (same link uuids)');
+    }
+
+    public function test_replace_adds_only_new_and_keeps_existing(): void
+    {
+        $repo = $this->repo();
+        $repo->assignPermissionToRole('role-1', 'perm-1');
+        $repo->assignPermissionToRole('role-1', 'perm-2');
+        $kept = $this->liveLinks('role-1');
+        $this->recordedEvents = [];
+
+        $ok = $repo->replaceRolePermissions('role-1', ['perm-1', 'perm-2', 'perm-3']);
+
+        self::assertTrue($ok);
+        $assigned = $this->eventsOfType(RolePermissionAssignedEvent::class);
+        self::assertCount(1, $assigned, 'only the genuinely new link is assigned');
+        self::assertSame('perm-3', $assigned[0]->permissionUuid);
+        self::assertCount(0, $this->eventsOfType(RolePermissionRevokedEvent::class));
+        self::assertSame(0, $this->tombstoneCount('role-1'), 'untouched links are not revoked');
+
+        $after = $this->liveLinks('role-1');
+        self::assertSame($kept['perm-1'], $after['perm-1'] ?? null, 'perm-1 keeps its original row');
+        self::assertSame($kept['perm-2'], $after['perm-2'] ?? null, 'perm-2 keeps its original row');
+        self::assertArrayHasKey('perm-3', $after);
+    }
+
+    public function test_replace_removes_only_absent_and_keeps_rest(): void
+    {
+        $repo = $this->repo();
+        $repo->assignPermissionToRole('role-1', 'perm-1');
+        $repo->assignPermissionToRole('role-1', 'perm-2');
+        $repo->assignPermissionToRole('role-1', 'perm-3');
+        $kept = $this->liveLinks('role-1');
+        $this->recordedEvents = [];
+
+        $ok = $repo->replaceRolePermissions('role-1', ['perm-1', 'perm-2']);
+
+        self::assertTrue($ok);
+        $revoked = $this->eventsOfType(RolePermissionRevokedEvent::class);
+        self::assertCount(1, $revoked, 'only the absent link is revoked');
+        self::assertSame('perm-3', $revoked[0]->permissionUuid);
+        self::assertCount(0, $this->eventsOfType(RolePermissionAssignedEvent::class));
+
+        $after = $this->liveLinks('role-1');
+        self::assertSame(['perm-1', 'perm-2'], array_keys($after));
+        self::assertSame($kept['perm-1'], $after['perm-1'], 'kept links retain their original rows');
+        self::assertSame($kept['perm-2'], $after['perm-2']);
+    }
+
+    public function test_replace_with_overlap_touches_only_the_diff(): void
+    {
+        // [perm-1, perm-2] -> [perm-2, perm-3]: perm-1 removed, perm-3 added, perm-2 kept.
+        $repo = $this->repo();
+        $repo->assignPermissionToRole('role-1', 'perm-1');
+        $repo->assignPermissionToRole('role-1', 'perm-2');
+        $keptUuid = $this->liveLinks('role-1')['perm-2'];
+        $this->recordedEvents = [];
+
+        $ok = $repo->replaceRolePermissions('role-1', ['perm-2', 'perm-3']);
+
+        self::assertTrue($ok);
+        $revoked = $this->eventsOfType(RolePermissionRevokedEvent::class);
+        $assigned = $this->eventsOfType(RolePermissionAssignedEvent::class);
+        self::assertCount(1, $revoked);
+        self::assertSame('perm-1', $revoked[0]->permissionUuid);
+        self::assertCount(1, $assigned);
+        self::assertSame('perm-3', $assigned[0]->permissionUuid);
+
+        $after = $this->liveLinks('role-1');
+        self::assertSame(['perm-2', 'perm-3'], array_keys($after));
+        self::assertSame($keptUuid, $after['perm-2'], 'the overlapping link is not churned');
+    }
+
+    public function test_replace_empty_revokes_all(): void
+    {
+        $repo = $this->repo();
+        $repo->assignPermissionToRole('role-1', 'perm-1');
+        $repo->assignPermissionToRole('role-1', 'perm-2');
+        $this->recordedEvents = [];
+
+        $ok = $repo->replaceRolePermissions('role-1', []);
+
+        self::assertTrue($ok);
+        self::assertCount(2, $this->eventsOfType(RolePermissionRevokedEvent::class));
+        self::assertCount(0, $this->eventsOfType(RolePermissionAssignedEvent::class));
+        self::assertSame([], $this->liveLinks('role-1'));
+    }
+
+    public function test_replace_dedupes_duplicate_input(): void
+    {
+        $repo = $this->repo();
+        $this->recordedEvents = [];
+
+        $ok = $repo->replaceRolePermissions('role-1', ['perm-1', 'perm-1', 'perm-2']);
+
+        self::assertTrue($ok);
+        self::assertCount(2, $this->eventsOfType(RolePermissionAssignedEvent::class), 'duplicate input collapses to one assign each');
+        self::assertSame(['perm-1', 'perm-2'], array_keys($this->liveLinks('role-1')));
+        self::assertSame(2, $this->liveRowCount('role-1'), 'exactly one live row per permission');
+    }
+
+    /**
+     * Live (non-tombstoned) role→permission links, as permission_uuid => link uuid, sorted by key.
+     *
+     * @return array<string, string>
+     */
+    private function liveLinks(string $roleUuid): array
+    {
+        $stmt = $this->connection->getPDO()->prepare(
+            'SELECT permission_uuid, uuid FROM role_permissions WHERE role_uuid = ? AND deleted_at IS NULL'
+        );
+        $stmt->execute([$roleUuid]);
+        $out = [];
+        foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+            $out[(string) $row['permission_uuid']] = (string) $row['uuid'];
+        }
+        ksort($out);
+        return $out;
+    }
+
+    private function liveRowCount(string $roleUuid): int
+    {
+        $stmt = $this->connection->getPDO()->prepare(
+            'SELECT COUNT(*) FROM role_permissions WHERE role_uuid = ? AND deleted_at IS NULL'
+        );
+        $stmt->execute([$roleUuid]);
+        return (int) $stmt->fetchColumn();
+    }
+
+    private function tombstoneCount(string $roleUuid): int
+    {
+        $stmt = $this->connection->getPDO()->prepare(
+            'SELECT COUNT(*) FROM role_permissions WHERE role_uuid = ? AND deleted_at IS NOT NULL'
+        );
+        $stmt->execute([$roleUuid]);
+        return (int) $stmt->fetchColumn();
+    }
 }


### PR DESCRIPTION
replaceRolePermissions() previously revoked every existing grant and re-inserted the entire desired set, leaving a soft-delete tombstone per grant and emitting a full revoke+assign event burst on every run (e.g. each permissions:sync), even when nothing changed.

It now diffs the desired set against the role's current live grants and touches only the difference: revoke removed links, assign new ones, leave unchanged grants alone. An unchanged sync/edit writes nothing and emits no events. End-state semantics are unchanged; duplicate input UUIDs are de-duplicated.

Both callers benefit: AegisPermissionProvider::syncRoles (permissions:sync) and RoleController (admin-UI role edit).